### PR TITLE
Replace ${file_name} with the current file name.

### DIFF
--- a/src/main/java/com/mycila/maven/plugin/license/document/Document.java
+++ b/src/main/java/com/mycila/maven/plugin/license/document/Document.java
@@ -74,7 +74,7 @@ public final class Document {
         }
         try {
             String fileHeader = readFirstLines(file, header.getLineCount() + 10, encoding).replaceAll(" *\r?\n", "\n");
-            return header.isMatchForText(fileHeader,headerDefinition,true);
+            return header.isMatchForText(fileHeader,headerDefinition, true, file.getName());
         }
         catch (IOException e) {
             throw new IllegalStateException("Cannot read file " + getFile() + ". Cause: " + e.getMessage(), e);
@@ -82,7 +82,8 @@ public final class Document {
     }
 
     public void updateHeader(Header header) {
-        String headerStr = header.applyDefinitionAndSections(parser.getHeaderDefinition(), parser.getFileContent().isUnix());
+        String headerStr = header.applyDefinitionAndSections(parser.getHeaderDefinition(),
+                parser.getFileContent().isUnix(), file.getName());
         parser.getFileContent().insert(parser.getBeginPosition(), headerStr);
     }
 

--- a/src/main/java/com/mycila/maven/plugin/license/header/Header.java
+++ b/src/main/java/com/mycila/maven/plugin/license/header/Header.java
@@ -93,7 +93,7 @@ public final class Header {
         return unix ? "\n" : "\r\n";
     }
 
-    public String buildForDefinition(HeaderDefinition type, boolean unix) {
+    public String buildForDefinition(HeaderDefinition type, boolean unix, String filename) {
         StringBuilder newHeader = new StringBuilder();
         if (notEmpty(type.getFirstLine())) {
             newHeader.append(type.getFirstLine().replace("EOL", eol(unix)));
@@ -108,7 +108,7 @@ public final class Header {
             newHeader.append(type.getEndLine().replace("EOL", eol(unix)));
             newHeader.append(eol(unix));
         }
-        return newHeader.toString();
+        return newHeader.toString().replace("${file_name}", filename);
     }
 
     @Override
@@ -134,9 +134,9 @@ public final class Header {
      *            if true, unix line-endings will be used
      * @return true if the header is matched
      */
-    public boolean isMatchForText(String potentialFileHeader, HeaderDefinition headerDefinition, boolean unix) {
+    public boolean isMatchForText(String potentialFileHeader, HeaderDefinition headerDefinition, boolean unix, String filename) {
 
-        String expected = buildForDefinition(headerDefinition, unix);
+        String expected = buildForDefinition(headerDefinition, unix, filename);
 
         SortedMap<Integer, HeaderSection> sectionsByIndex = computeSectionsByIndex(expected);
 
@@ -148,9 +148,9 @@ public final class Header {
         return recursivelyFindMatch(potentialFileHeader, headerDefinition, textBetweenSections, sectionsInOrder, 0, 0);
     }
     
-    public String applyDefinitionAndSections(HeaderDefinition headerDefinition, boolean unix) {
+    public String applyDefinitionAndSections(HeaderDefinition headerDefinition, boolean unix, String filename) {
         
-        String expected = buildForDefinition(headerDefinition, unix);
+        String expected = buildForDefinition(headerDefinition, unix, filename);
 
         SortedMap<Integer, HeaderSection> sectionsByIndex = computeSectionsByIndex(expected);
 

--- a/src/test/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinitionTest.java
+++ b/src/test/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinitionTest.java
@@ -58,8 +58,8 @@ public final class AdditionalHeaderDefinitionTest {
         //FileUtils.write(new File("src/test/resources/test-header3.txt"), header.buildForDefinition(loader.getDefinitions().get("xquery")));
 
         final String content = FileUtils.read(new File("src/test/resources/test-header3.txt"), System.getProperty("file.encoding"));
-        assertEquals(header.buildForDefinition(loader.getDefinitions().get("xquery"), content.indexOf("\n") == -1),
-                content);
+        assertEquals(header.buildForDefinition(loader.getDefinitions().get("xquery"), content.indexOf("\n") == -1,
+                "test-header3.txt"), content);
     }
 
     @Test
@@ -82,7 +82,7 @@ public final class AdditionalHeaderDefinitionTest {
         props.put("year", "2008");
         Header header = new Header(getClass().getResource("/check/header.txt"), "UTF-8", props, null);
 
-        System.out.println(header.buildForDefinition(loader.getDefinitions().get("text"), false));
+        System.out.println(header.buildForDefinition(loader.getDefinitions().get("text"), false, "header.txt"));
     }
 
     @Test
@@ -106,7 +106,7 @@ public final class AdditionalHeaderDefinitionTest {
         //FileUtils.write(new File("src/test/resources/test-header4.txt"), header.buildForDefinition(loader.getDefinitions().get("csregion"), false), System.getProperty("file.encoding"));
 
         final String content = FileUtils.read(new File("src/test/resources/test-header4.txt"), System.getProperty("file.encoding"));
-        assertEquals(header.buildForDefinition(loader.getDefinitions().get("csregion"), content.indexOf("\n") == -1),
-                content);
+        assertEquals(header.buildForDefinition(loader.getDefinitions().get("csregion"), content.indexOf("\n") == -1,
+                "test-header4.txt"), content);
     }
 }

--- a/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
+++ b/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
@@ -36,7 +36,8 @@ public final class DefaultHeaderDefinitionTest {
         Header header = new Header(getClass().getResource("/test-header1.txt"), "UTF-8", props, null);
         for (HeaderDefinition definition : HeaderType.defaultDefinitions().values()) {
             final String content = FileUtils.read(new File(format("src/test/resources/styles/%s.txt", definition.getType())), System.getProperty("file.encoding"));
-            assertEquals("Bad header for type: " + definition.getType(), content, header.buildForDefinition(definition, !content.contains("\n")));
+            assertEquals("Bad header for type: " + definition.getType(), content,
+                    header.buildForDefinition(definition, !content.contains("\n"), "test-header1.txt"));
         }
     }
 }

--- a/src/test/java/com/mycila/maven/plugin/license/header/HeaderTest.java
+++ b/src/test/java/com/mycila/maven/plugin/license/header/HeaderTest.java
@@ -43,7 +43,8 @@ public final class HeaderTest {
 
         final File file = new File("src/test/resources/test-header2.txt");
         final String content = FileUtils.read(file, System.getProperty("file.encoding"));
-        assertEquals(content, header.buildForDefinition(HeaderType.ASP.getDefinition(), content.indexOf("\n") == -1));
+        assertEquals(content, header.buildForDefinition(HeaderType.ASP.getDefinition(), content.indexOf("\n") == -1,
+                "test-header2.txt"));
     }
     
     @Test
@@ -67,7 +68,7 @@ public final class HeaderTest {
         h1.append(" *\n");
         h1.append(" * My License\n");
         h1.append(" */\n");
-        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true));
+        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * This potential header should fail because the date is invalid
@@ -78,7 +79,7 @@ public final class HeaderTest {
         h2.append(" *\n");
         h2.append(" * My License\n");
         h2.append(" */\n");
-        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true));
+        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * This potential header should match, even with multiple lines
@@ -90,7 +91,7 @@ public final class HeaderTest {
         h3.append(" *\n");
         h3.append(" * My License\n");
         h3.append(" */\n");
-        assertTrue(header.isMatchForText(h3.toString(), headerDefinition, true));
+        assertTrue(header.isMatchForText(h3.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * Assert that the header, rendered with default values, looks correct
@@ -101,7 +102,7 @@ public final class HeaderTest {
         h4.append(" *\n");
         h4.append(" * My License\n");
         h4.append(" */\n");
-        String headerText = header.applyDefinitionAndSections(headerDefinition, true);
+        String headerText = header.applyDefinitionAndSections(headerDefinition, true, "test-header5.txt");
         assertEquals(headerText,h4.toString());
     }
     
@@ -138,7 +139,7 @@ public final class HeaderTest {
         h1.append(" *\n");
         h1.append(" * My License\n");
         h1.append(" */\n");
-        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true));
+        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * This potential header should fail because there is no space in there to match
@@ -149,7 +150,7 @@ public final class HeaderTest {
         h2.append(" *\n");
         h2.append(" * My License\n");
         h2.append(" */\n");
-        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true));
+        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * Assert that the header, rendered with default values, looks correct
@@ -160,7 +161,7 @@ public final class HeaderTest {
         h3.append(" *\n");
         h3.append(" * My License\n");
         h3.append(" */\n");
-        String headerText = header.applyDefinitionAndSections(headerDefinition, true);
+        String headerText = header.applyDefinitionAndSections(headerDefinition, true, "test-header5.txt");
         assertEquals(headerText,h3.toString());
     }
     
@@ -187,7 +188,7 @@ public final class HeaderTest {
         h1.append(" *\n");
         h1.append(" * My License\n");
         h1.append(" */\n");
-        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true));
+        assertTrue(header.isMatchForText(h1.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * This potential header should fail because "Name" => "NamE"
@@ -199,7 +200,7 @@ public final class HeaderTest {
         h2.append(" *\n");
         h2.append(" * My License\n");
         h2.append(" */\n");
-        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true));
+        assertFalse(header.isMatchForText(h2.toString(), headerDefinition, true, "test-header5.txt"));
         
         /**
          * Assert that the header, rendered with default values, looks correct
@@ -211,7 +212,7 @@ public final class HeaderTest {
         h3.append(" *\n");
         h3.append(" * My License\n");
         h3.append(" */\n");
-        String headerText = header.applyDefinitionAndSections(headerDefinition, true);
+        String headerText = header.applyDefinitionAndSections(headerDefinition, true, "test-header5.txt");
         assertEquals(headerText,h3.toString());
     }
 }


### PR DESCRIPTION
Proposed fix for issue #1 by passing Document#file.getName() to the header. The header
then replaces every occurence of $[file_name} with the given file name.
This is a workaround for the fact that the header is otherwise
constructed before a certain file is opened.
