### PR TITLE
Add support for per-line open/closing comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ The plugin has been designed so that it is very easy to add new supports for new
 	-->
 ```
 
+ - `XML_PER_LINE` (alternate XML-like comments)
+
+```
+	<!-- My first comment  -->
+	<!-- My second comment -->
+```
+
+(automatically right-adjusts the closing comment)
+
+
  - `DOUBLETILDE_STYLE` (APT-like comments): *.apt
 
 ```
@@ -355,11 +365,13 @@ In license-maven-plugin, each header style is defined by patterns to detect it a
             <firstLine>/**</firstLine>
             <beforeEachLine> * </beforeEachLine>
             <endLine> */</endLine>
+            <afterEachLine></afterEachLine>
             <!--skipLine></skipLine-->
             <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
             <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>
             <allowBlankLines>false</allowBlankLines>
             <isMultiline>true</isMultiline>
+            <padLines>false</padLines>
         </javadoc_style>
     </additionalHeaders>
 
@@ -371,11 +383,13 @@ And for XML:
             <firstLine><![CDATA[<!--\n]]></firstLine>
             <beforeEachLine>    </beforeEachLine>
             <endLine><![CDATA[-->]]></endLine>
+            <afterEachLine></afterEachLine>
             <skipLine><![CDATA[^<\?xml.*>$]]></skipLine>
             <firstLineDetectionPattern><![CDATA[(\s|\t)*<!--.*$]]></firstLineDetectionPattern>
             <lastLineDetectionPattern><![CDATA[.*-->(\s|\t)*$]]></lastLineDetectionPattern>
             <allowBlankLines>false</allowBlankLines>
             <isMultiline>true</isMultiline>
+            <padLines>false</padLines>
         </javadoc_style>
     </additionalHeaders>
 

--- a/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
+++ b/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
@@ -26,15 +26,18 @@ import java.util.regex.Pattern;
  */
 public final class HeaderDefinition {
     private final String type;
-    private String firstLine;
-    private String beforeEachLine;
-    private String endLine;
+    private String firstLine = "";
+    private String beforeEachLine = "";
+    private String endLine = "";
+    private String afterEachLine = "";
     private Boolean allowBlankLines;
 
     private Pattern skipLinePattern;
     private Pattern firstLineDetectionPattern;
     private Pattern lastLineDetectionPattern;
     private Boolean isMultiline;
+
+    private boolean padLines = false;
 
     /**
      * Constructs a new <code>HeaderDefinition</code> object with every header definition properties.
@@ -44,22 +47,31 @@ public final class HeaderDefinition {
      * @param beforeEachLine            The string to output before the content of each line of this header (except
      *                                  firstLine and endLine).
      * @param endLine                   The string to output before the content of the last line of this header.
+     * @param afterEachLine             The string to output after the content of each line of this header (except
+     *                                  firstLine and endLine).
      * @param skipLinePattern           The pattern of lines to skip before being allowed to output this header or null
      *                                  if it can be outputted from the line of the file.
      * @param firstLineDetectionPattern The pattern to detect the first line of a previous header.
      * @param lastLineDetectionPattern  The pattern to detect the last line of a previous header.
      * @throws IllegalArgumentException If the type name is null.
      */
-    public HeaderDefinition(String type, String firstLine, String beforeEachLine, String endLine, String skipLinePattern, String firstLineDetectionPattern, String lastLineDetectionPattern, boolean allowBlankLines, boolean isMultiline) {
+    public HeaderDefinition(String type,
+                            String firstLine, String beforeEachLine,
+                            String endLine, String afterEachLine,
+                            String skipLinePattern,
+                            String firstLineDetectionPattern, String lastLineDetectionPattern,
+                            boolean allowBlankLines, boolean isMultiline, boolean padLines) {
         this(type);
         this.firstLine = firstLine;
         this.beforeEachLine = beforeEachLine;
         this.endLine = endLine;
+        this.afterEachLine = afterEachLine;
         this.skipLinePattern = compile(skipLinePattern);
         this.firstLineDetectionPattern = compile(firstLineDetectionPattern);
         this.lastLineDetectionPattern = compile(lastLineDetectionPattern);
         this.allowBlankLines = allowBlankLines;
         this.isMultiline = isMultiline;
+        this.padLines = padLines;
         if (!"unknown".equals(type)) validate();
     }
 
@@ -95,12 +107,20 @@ public final class HeaderDefinition {
         return endLine;
     }
 
+    public String getAfterEachLine() {
+        return afterEachLine;
+    }
+
     public String getType() {
         return type;
     }
 
     public boolean allowBlankLines() {
         return allowBlankLines;
+    }
+
+    public boolean isPadLines() {
+        return padLines;
     }
 
     /**
@@ -161,8 +181,12 @@ public final class HeaderDefinition {
             beforeEachLine = value;
         else if ("endLine".equalsIgnoreCase(property))
             endLine = value;
+        else if ("afterEachLine".equalsIgnoreCase(property))
+            afterEachLine = value;
         else if ("skipLine".equalsIgnoreCase(property))
             skipLinePattern = compile(value);
+        else if ("padLines".equalsIgnoreCase(property))
+            padLines = Boolean.parseBoolean(value);
         else if ("firstLineDetectionPattern".equalsIgnoreCase(property))
             firstLineDetectionPattern = compile(value);
         else if ("lastLineDetectionPattern".equalsIgnoreCase(property))
@@ -180,6 +204,7 @@ public final class HeaderDefinition {
         check("firstLine", this.firstLine);
         check("beforeEachLine", this.beforeEachLine);
         check("endLine", this.endLine);
+        check("afterEachLine", this.afterEachLine);
         check("firstLineDetectionPattern", this.firstLineDetectionPattern);
         check("lastLineDetectionPattern", this.lastLineDetectionPattern);
         check("isMultiline", this.isMultiline);
@@ -194,7 +219,7 @@ public final class HeaderDefinition {
     }
 
     private void check(String name, String value) {
-        if (isEmpty(value)) {
+        if (value == null) {
             throw new IllegalStateException(String.format("The property '%s' is missing for header definition '%s'", name, type));
         }
     }

--- a/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
+++ b/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
@@ -29,36 +29,37 @@ import java.util.Map;
 public enum HeaderType {
     ////////// COMMENT TYPES //////////
 
-    //              FirstLine           Before              EndLine             SkipLine                    FirstLineDetection              LastLineDetection       allowBlankLines isMultiline
+    //              FirstLine           Before              EndLine             After             SkipLine                    FirstLineDetection              LastLineDetection       allowBlankLines isMultiline
     //generic
-    JAVADOC_STYLE("/**", " * ", " */", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true),
-    SCRIPT_STYLE("#", "# ", "#EOL", "^#!.*$", "#.*$", "#.*$", false, false),
-    HAML_STYLE("-#", "-# ", "-#EOL", "^-#!.*$", "-#.*$", "-#.*$", false, false),
-    XML_STYLE("<!--EOL", "    ", "EOL-->", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", true, true),
-    SEMICOLON_STYLE(";", "; ", ";EOL", null, ";.*$", ";.*$", false, false),
-    APOSTROPHE_STYLE("'", "' ", "'EOL", null, "'.*$", "'.*$", false, false),
-    EXCLAMATION_STYLE("!", "! ", "!EOL", null, "!.*$", "!.*$", false, false),
-    DOUBLEDASHES_STYLE("--", "-- ", "--EOL", null, "--.*$", "--.*$", false, false),
-    SLASHSTAR_STYLE("/*", " * ", " */", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true),
-    BRACESSTAR_STYLE("\\{*", " * ", " *\\}", null, "(\\s|\\t)*\\{\\*.*$", ".*\\*\\}(\\s|\\t)*$", false, true),
-    SHARPSTAR_STYLE("#*", " * ", " *#", null, "(\\s|\\t)*#\\*.*$", ".*\\*#(\\s|\\t)*$", false, true),
-    DOUBLETILDE_STYLE("~~", "~~ ", "~~EOL", null, "~~.*$", "~~.*$", false, false),
-    DYNASCRIPT_STYLE("<%--EOL", "    ", "EOL--%>", null, "(\\s|\\t)*<%--.*$", ".*--%>(\\s|\\t)*$", true, true),
-    DYNASCRIPT3_STYLE("<!---EOL", "    ", "EOL--->", null, "(\\s|\\t)*<!---.*$", ".*--->(\\s|\\t)*$", true, true),
-    PERCENT3_STYLE("%%%", "%%% ", "%%%EOL", null, "%%%.*$", "%%%.*$", false, false),
-    EXCLAMATION3_STYLE("!!!", "!!! ", "!!!EOL", null, "!!!.*$", "!!!.*$", false, false),
+    JAVADOC_STYLE("/**", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+    SCRIPT_STYLE("#", "# ", "#EOL", "", "^#!.*$", "#.*$", "#.*$", false, false, false),
+    HAML_STYLE("-#", "-# ", "-#EOL", "", "^-#!.*$", "-#.*$", "-#.*$", false, false, false),
+    XML_STYLE("<!--EOL", "    ", "EOL-->", "", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", true, true, false),
+    XML_PER_LINE("EOL", "<!-- ", "EOL", " -->", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", true, false, true),
+    SEMICOLON_STYLE(";", "; ", ";EOL", "", null, ";.*$", ";.*$", false, false, false),
+    APOSTROPHE_STYLE("'", "' ", "'EOL", "", null, "'.*$", "'.*$", false, false, false),
+    EXCLAMATION_STYLE("!", "! ", "!EOL", "", null, "!.*$", "!.*$", false, false, false),
+    DOUBLEDASHES_STYLE("--", "-- ", "--EOL", "", null, "--.*$", "--.*$", false, false, false),
+    SLASHSTAR_STYLE("/*", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+    BRACESSTAR_STYLE("\\{*", " * ", " *\\}", "", null, "(\\s|\\t)*\\{\\*.*$", ".*\\*\\}(\\s|\\t)*$", false, true, false),
+    SHARPSTAR_STYLE("#*", " * ", " *#", "", null, "(\\s|\\t)*#\\*.*$", ".*\\*#(\\s|\\t)*$", false, true, false),
+    DOUBLETILDE_STYLE("~~", "~~ ", "~~EOL", "", null, "~~.*$", "~~.*$", false, false, false),
+    DYNASCRIPT_STYLE("<%--EOL", "    ", "EOL--%>", "", null, "(\\s|\\t)*<%--.*$", ".*--%>(\\s|\\t)*$", true, true, false),
+    DYNASCRIPT3_STYLE("<!---EOL", "    ", "EOL--->", "", null, "(\\s|\\t)*<!---.*$", ".*--->(\\s|\\t)*$", true, true, false),
+    PERCENT3_STYLE("%%%", "%%% ", "%%%EOL", "", null, "%%%.*$", "%%%.*$", false, false, false),
+    EXCLAMATION3_STYLE("!!!", "!!! ", "!!!EOL", "", null, "!!!.*$", "!!!.*$", false, false, false),
 
-    DOUBLESLASH_STYLE("//", "// ", "//EOL", null, "//.*$", "//.*$", false, false),
+    DOUBLESLASH_STYLE("//", "// ", "//EOL", "", null, "//.*$", "//.*$", false, false, false),
     // non generic
-    PHP("/*", " * ", " */", "^<\\?php.*$", "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true),
-    ASP("<%", "    ", "%>", null, "(\\s|\\t)*<%[^@].*$", ".*%>(\\s|\\t)*$", true, true),
-    LUA("--[[EOL", "    ", "EOL]]", null, "--\\[\\[$", "\\]\\]$", true, true),
-    FTL("<#--EOL", "    ", "EOL-->", null, "(\\s|\\t)*<#--.*$", ".*-->(\\s|\\t)*$", true, true),
-    FTL_ALT("[#--EOL", "    ", "EOL--]", "\\[#ftl(\\s.*)?\\]", "(\\s|\\t)*\\[#--.*$", ".*--\\](\\s|\\t)*$", true, true),
-    TEXT("====", "    ", "====EOL", null, "====.*$", "====.*$", true, true),
-    BATCH("@REM", "@REM ", "@REMEOL", null, "@REM.*$", "@REM.*$", false, false),
+    PHP("/*", " * ", " */", "", "^<\\?php.*$", "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+    ASP("<%", "    ", "%>", "", null, "(\\s|\\t)*<%[^@].*$", ".*%>(\\s|\\t)*$", true, true, false),
+    LUA("--[[EOL", "    ", "EOL]]", "", null, "--\\[\\[$", "\\]\\]$", true, true, false),
+    FTL("<#--EOL", "    ", "EOL-->", "", null, "(\\s|\\t)*<#--.*$", ".*-->(\\s|\\t)*$", true, true, false),
+    FTL_ALT("[#--EOL", "    ", "EOL--]", "", "\\[#ftl(\\s.*)?\\]", "(\\s|\\t)*\\[#--.*$", ".*--\\](\\s|\\t)*$", true, true, false),
+    TEXT("====", "    ", "====EOL", "", null, "====.*$", "====.*$", true, true, false),
+    BATCH("@REM", "@REM ", "@REMEOL", "", null, "@REM.*$", "@REM.*$", false, false, false),
     // unknown
-    UNKNOWN("", "", "", null, null, null, false, false);
+    UNKNOWN("", "", "", "", null, null, null, false, false, false);
 
     ////////////////////////////////////
 
@@ -78,8 +79,11 @@ public enum HeaderType {
 
     private final HeaderDefinition definition;
 
-    private HeaderType(String firstLine, String beforeEachLine, String endLine, String skipLinePattern, String firstLineDetectionPattern, String endLineDetectionPattern, boolean allowBlankLines, boolean isMultiline) {
-        definition = new HeaderDefinition(this.name().toLowerCase(), firstLine, beforeEachLine, endLine, skipLinePattern, firstLineDetectionPattern, endLineDetectionPattern, allowBlankLines, isMultiline);
+    private HeaderType(String firstLine, String beforeEachLine,
+                       String endLine, String afterEachLine,
+                       String skipLinePattern, String firstLineDetectionPattern, String endLineDetectionPattern,
+                       boolean allowBlankLines, boolean isMultiline, boolean padLines) {
+        definition = new HeaderDefinition(this.name().toLowerCase(), firstLine, beforeEachLine, endLine, afterEachLine, skipLinePattern, firstLineDetectionPattern, endLineDetectionPattern, allowBlankLines, isMultiline, padLines);
     }
 
     /**

--- a/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
+++ b/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
@@ -34,4 +34,16 @@ public final class StringUtils {
         return s.substring(0, i + 1);
     }
 
+    public static String padRight(String s, int len) {
+        if (s == null || s.length() >= len) {
+            return s;
+        }
+
+        StringBuilder sb = new StringBuilder(len);
+        sb.append(s);
+        for (int i = s.length(); i < len; i++) {
+          sb.append(' ');
+        }
+        return sb.toString();
+    }
 }

--- a/src/test/java/com/mycila/maven/plugin/license/header/HeaderDefinitionTest.java
+++ b/src/test/java/com/mycila/maven/plugin/license/header/HeaderDefinitionTest.java
@@ -24,43 +24,49 @@ public final class HeaderDefinitionTest {
 
     @Test
     public void test_ok1() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", "skip", "firstDetect", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", "", "skip", "firstDetect", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test
     public void test_ok2() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", null, "firstDetect", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", "after", null, "firstDetect", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_missing_firstLine() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "", "before", "end", null, "firstDetect", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", null, "before", "end", "after", null, "firstDetect", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_missing_before() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "", "end", null, "firstDetect", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", null, "end", "after", null, "firstDetect", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_missing_end() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "", null, "firstDetect", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", null, "after", null, "firstDetect", "lastDetect", false, false, false);
+        def.validate();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_missing_after() throws Exception {
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", null, null, "firstDetect", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_missing_firstDetect() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", null, "", "lastDetect", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", "", null, "", "lastDetect", false, false, false);
         def.validate();
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_missing_lastDetect() throws Exception {
-        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", null, "firstDetect", "", false, false);
+        HeaderDefinition def = new HeaderDefinition("aa", "firstLine", "before", "end", "", null, "firstDetect", "", false, false, false);
         def.validate();
     }
 }

--- a/src/test/java/com/mycila/maven/plugin/license/header/HeaderTypeTest.java
+++ b/src/test/java/com/mycila/maven/plugin/license/header/HeaderTypeTest.java
@@ -26,7 +26,7 @@ public final class HeaderTypeTest {
     @Test
     public void test() throws Exception {
         assertEquals(HeaderType.ASP.getDefinition().getType(), "asp");
-        assertEquals(HeaderType.defaultDefinitions().size(), 25);
+        assertEquals(HeaderType.defaultDefinitions().size(), HeaderType.values().length);
         System.out.println(HeaderType.defaultDefinitions().keySet());
     }
 }

--- a/src/test/resources/styles/xml_per_line.txt
+++ b/src/test/resources/styles/xml_per_line.txt
@@ -1,0 +1,15 @@
+
+<!-- Copyright (C) ${year} http://code.google.com/p/maven-license-plugin/     -->
+<!--                                                                          -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License");          -->
+<!-- you may not use this file except in compliance with the License.         -->
+<!-- You may obtain a copy of the License at                                  -->
+<!--                                                                          -->
+<!--         http://www.apache.org/licenses/LICENSE-2.0                       -->
+<!--                                                                          -->
+<!-- Unless required by applicable law or agreed to in writing, software      -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS,        -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and      -->
+<!-- limitations under the License.                                           -->
+


### PR DESCRIPTION
- Add a new configuration field 'afterEachLine' which contains a values that gets attached
  to each line in the license header (matches beforeEachLine).
- add new configuration field 'padLines' which is a boolean. If true, all the lines in the
  license header get padded to the same length.
- add new style 'XML_PER_LINE' which generates license headers that use per-line comments:
  
  <!-- this is the first license line -->
  
  <!-- this is another line           -->
  
  <!--                                -->
  
  <!-- above is a blank line          -->
- make it possible to omit each of the firstLine, endLine, beforeEachLine and afterEachLine;
  if they are missing assume that they are the empty string.
- add test for xml_per_line
- add docs.
