### PR TITLE
license policy enforcement with maven project implementation.

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -136,7 +136,17 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.3.3</version>
+            <version>3.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-common-artifact-filters</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>2.2</version>
         </dependency>
 
         <dependency>
@@ -159,7 +169,14 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>10.0.1</version>
+            <version>16.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-verifier</artifactId>
+            <version>1.7.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -15,6 +15,53 @@
  */
 package com.mycila.maven.plugin.license;
 
+import static com.mycila.maven.plugin.license.document.DocumentType.defaultMapping;
+import static com.mycila.maven.plugin.license.util.FileUtils.asPath;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.deepToString;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Organization;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.xml.sax.InputSource;
+
+import com.mycila.maven.plugin.license.dependencies.LicenseMessage;
+import com.mycila.maven.plugin.license.dependencies.LicensePolicy;
 import com.mycila.maven.plugin.license.document.Document;
 import com.mycila.maven.plugin.license.document.DocumentFactory;
 import com.mycila.maven.plugin.license.document.DocumentPropertiesLoader;
@@ -27,37 +74,6 @@ import com.mycila.maven.plugin.license.header.HeaderType;
 import com.mycila.maven.plugin.license.util.Selection;
 import com.mycila.maven.plugin.license.util.resource.ResourceFinder;
 import com.mycila.xmltool.XMLDoc;
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.model.Organization;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.settings.Server;
-import org.apache.maven.settings.Settings;
-import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
-import org.apache.maven.settings.crypto.SettingsDecrypter;
-import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
-import org.apache.maven.settings.crypto.SettingsDecryptionResult;
-import org.xml.sax.InputSource;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static com.mycila.maven.plugin.license.document.DocumentType.defaultMapping;
-import static com.mycila.maven.plugin.license.util.FileUtils.asPath;
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Arrays.deepToString;
 
 /**
  * <b>Date:</b> 18-Feb-2008<br> <b>Author:</b> Mathieu Carbou
@@ -323,9 +339,34 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      */
     @Parameter(property = "license.skipExistingHeaders", defaultValue = "false")
     public boolean skipExistingHeaders = false;
+    
+	/**
+	 * When enforcing licenses on dependencies, exclude all but these scopes.
+	 */
+	@Parameter(property = "license.dependencies.scope", required = true, defaultValue = "runtime")
+	protected List<String> dependencyScopes;
+	
+	/**
+	 * Whether to enforce license.dependencies.allow list.
+	 */
+	@Parameter(property = "license.dependencies.enforce", required = true, defaultValue = "false")
+	protected boolean dependencyEnforce;
+	
+	/**
+	 * Block of {@link LicensePolicy} configuration for enforcing license adherence in dependencies.
+	 */
+	@Parameter(property = "license.dependencies.policies")
+	protected Set<LicensePolicy> dependencyPolicies;
+	
+	/**
+	 * Exception message prefix to display when an artifact is denied by one of the license policies.
+	 */
+	@Parameter(property = "license.dependencies.exceptionMessage", required = true, defaultValue = LicenseMessage.WARN_POLICY_DENIED)
+	protected String dependencyExceptionMessage;
 
-    @Component
-    public MavenProject project;
+
+    @Parameter(defaultValue = "${project}", required = true)
+    protected MavenProject project;
 
     /**
      * Maven settings.
@@ -337,6 +378,15 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      */
     @Component
     private SettingsDecrypter settingsDecrypter;
+    
+    @Component( hint = "default" )
+	protected DependencyGraphBuilder dependencyGraphBuilder;
+    
+    @Component
+    protected ProjectBuilder projectBuilder;
+    
+    @Parameter( defaultValue = "${session}")
+	public MavenSession session;
 
     protected abstract class AbstractCallback implements Callback {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -15,8 +15,16 @@
  */
 package com.mycila.maven.plugin.license;
 
+import com.mycila.maven.plugin.license.dependencies.AggregateLicensePolicyEnforcer;
+import com.mycila.maven.plugin.license.dependencies.LicenseMap;
+import com.mycila.maven.plugin.license.dependencies.LicensePolicy;
+import com.mycila.maven.plugin.license.dependencies.LicensePolicyEnforcerResult;
+import com.mycila.maven.plugin.license.dependencies.MavenProjectLicenses;
 import com.mycila.maven.plugin.license.document.Document;
 import com.mycila.maven.plugin.license.header.Header;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.License;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -24,8 +32,14 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 
 /**
  * Check if the source files of the project have a valid license header
@@ -66,6 +80,25 @@ public final class LicenseCheckMojo extends AbstractLicenseMojo {
                 debug("Header OK in: %s", document.getFilePath());
             }
         };
+
+        if(dependencyEnforce) {
+        	//TODO(rremer) config-driven factory of the LicenseMap implementation	
+		    final LicenseMap licenseMap = new MavenProjectLicenses(session, project, dependencyGraphBuilder, projectBuilder, dependencyScopes, getLog());
+		    final AggregateLicensePolicyEnforcer enforcer = new AggregateLicensePolicyEnforcer(dependencyPolicies);
+		    final Map<Artifact, LicensePolicyEnforcerResult> licenseResult = enforcer.apply(licenseMap);
+		    final Set<LicensePolicyEnforcerResult> deniedLicenseResult = licenseResult.values().stream()
+		    		.filter(result -> result.getRuling().equals(LicensePolicy.Rule.DENY))
+		    		.collect(Collectors.toSet());
+		    
+		    if (deniedLicenseResult.size() != 0) {
+		    	final StringBuilder licenseExceptionMsg = new StringBuilder(dependencyExceptionMessage);
+		    	deniedLicenseResult.stream().forEach(result -> {
+		    		licenseExceptionMsg.append(System.lineSeparator());
+		    		licenseExceptionMsg.append(result);
+		    	});
+		    	throw new MojoExecutionException(licenseExceptionMsg.toString());
+		    }
+        }
 
         execute(callback);
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+/**
+ * Base class for all policy enforcer implementations.
+ * 
+ * @author Royce Remer
+ *
+ * @param <T>
+ */
+public abstract class AbstractLicensePolicyEnforcer<T> implements LicensePolicyEnforcer<T> {
+	private final LicensePolicy policy;
+
+	public AbstractLicensePolicyEnforcer(final LicensePolicy policy) {
+		this.policy = policy;
+	}
+
+	public LicensePolicy getPolicy() {
+		return policy;
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.License;
+
+import com.mycila.maven.plugin.license.dependencies.LicensePolicy.Rule;
+
+/**
+ * Aggregate license policy enforcement with default enforcer bindings based on {@link LicensePolicy.Type}.
+ * 
+ * Rules are applied in the following order:
+ * 1) defaultPolicy: unless overridden via setDefaultPolicy, this will DENY all artifacts.
+ * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule.APPROVE}
+ * 3) DENY policies: any policy in the Set which have {@link LIcensePolicy.Rule.DENY}
+ * 
+ * @author Royce Remer
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class AggregateLicensePolicyEnforcer {
+	private final Set<LicensePolicy> policies;
+	private LicensePolicyEnforcer defaultPolicy;
+	private Set<LicensePolicyEnforcer> enforcers;
+	
+	public AggregateLicensePolicyEnforcer(final Set<LicensePolicy> policies) {
+		this.policies = policies;
+		this.defaultPolicy = new DefaultLicensePolicyEnforcer();
+		this.enforcers = policies.stream().map(policy -> initPolicyEnforcer(policy)).collect(Collectors.toSet());
+	}
+	
+	/**
+	 * Initialize an {@LicensePolicyEnforcer} implementation based on its {@link LicensePolicy.Type}.
+	 * 
+	 * @param policy - a single license policy which needs enforcement.
+	 * @return
+	 */
+	private static LicensePolicyEnforcer<?> initPolicyEnforcer(final LicensePolicy policy) {
+		switch (policy.getType()) {
+		case LICENSE_NAME:
+			return new LicenseNameLicensePolicyEnforcer(policy);
+		case ARTIFACT_PATTERN:
+			return new ArtifactLicensePolicyEnforcer(policy);
+		case LICENSE_URL:
+			return new LicenseURLLicensePolicyEnforcer(policy);
+		default:
+			return new DefaultLicensePolicyEnforcer();
+		}
+	}
+	
+	/**
+	 * Get a Set of policy enforces that have a given rule (approve/deny) and type (artifact/license).
+	 * 
+	 * @param rule - the {@link LicensePolicy.Rule} to filter all enforcers by.
+	 * @return
+	 */
+	private Set<LicensePolicyEnforcer> getEnforcers(final LicensePolicy.Rule rule) {
+		return enforcers.stream()
+				.filter(e -> e.getPolicy().getRule() == rule)
+				.collect(Collectors.toSet());
+	}
+	
+	/**
+	 * Helper method for taking a single iteration of license to set of artifacts, and applying a policy enforcer.
+	 * 
+	 * @param license
+	 * @param artifacts
+	 * @param enforcer
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<Artifact, LicensePolicyEnforcerResult> apply(final License license, final Set<Artifact> artifacts, final LicensePolicyEnforcer enforcer) {
+		final Map<Artifact, LicensePolicyEnforcerResult> results = new HashMap<Artifact, LicensePolicyEnforcerResult>();
+		
+		final LicensePolicy.Rule filter = enforcer.getPolicy().getRule();
+		
+		artifacts.forEach(artifact -> {
+			LicensePolicy.Rule ruling = LicensePolicy.Rule.DENY;
+			if (enforcer.getType() == License.class) {
+				ruling = LicensePolicy.Rule.valueOf(enforcer.apply(license));
+			} else if (enforcer.getType() == Artifact.class) {
+				ruling = LicensePolicy.Rule.valueOf(enforcer.apply(artifact));
+			}
+			results.put(artifact, new LicensePolicyEnforcerResult(enforcer.getPolicy(), license, artifact, ruling));
+		});
+		
+		// if this was an APPROVE rule, only return approvals. If a DENY rule, only return denials
+		return results.entrySet().stream()
+				.filter(result -> filter.equals(result.getValue().getRuling()))
+				.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+	}
+	
+	/**
+	 * Helper method for taking a full map of License:Set<Artifact> and building a rulings map from a policy enforcer.
+	 * 
+	 * @param licenseMap
+	 * @param enforcer
+	 * @return
+	 */
+	private Map<Artifact, LicensePolicyEnforcerResult> apply(final Map<License, Set<Artifact>> licenseMap, final LicensePolicyEnforcer enforcer) {
+		final Map<Artifact, LicensePolicyEnforcerResult> results = new HashMap<Artifact, LicensePolicyEnforcerResult>();
+		
+		licenseMap.forEach((license, artifactSet) -> {
+			results.putAll(apply(license, artifactSet, enforcer));
+		});
+		return results;
+	}
+	
+	
+	/**
+	 * Take a map of {@link License} keys and the Set of {@link Artifact} attributed to them,
+	 * applying the internal set of {@link LicensePolicyEnforcer} implementations on them,
+	 * and returning a mapping of Artifact keys to the boolean enforcement decision made.
+	 * 
+	 * @param licenseMap - the underlying LicenseMap interface types
+	 * @return final policy decision map on each artifact
+	 */
+	@SuppressWarnings("unchecked")
+	public Map<Artifact, LicensePolicyEnforcerResult> apply(final Map<License, Set<Artifact>> licenseMap) {
+		final Map<Artifact, LicensePolicyEnforcerResult> results = new HashMap<Artifact, LicensePolicyEnforcerResult>();
+		
+		// apply the default policy to all artifacts, populating the map
+		licenseMap.entrySet().stream().forEach(entry -> {
+			License license = entry.getKey();
+			entry.getValue().forEach(
+					artifact -> results.putIfAbsent(artifact, new LicensePolicyEnforcerResult(defaultPolicy.getPolicy(),
+							license, artifact, LicensePolicy.Rule.valueOf(defaultPolicy.apply(artifact)))));
+		});
+
+		// apply approval rules, updating the map
+		getEnforcers(LicensePolicy.Rule.APPROVE).forEach(enforcer -> {
+			results.putAll(apply(licenseMap, enforcer));
+		});
+		
+		// apply deny rules, updating the map
+		getEnforcers(LicensePolicy.Rule.DENY).forEach(enforcer -> {
+			results.putAll(apply(licenseMap, enforcer));
+		});
+
+		return results;
+	}
+	
+	/**
+	 * Take an {@link LicenseMap} implementation, getting its licenseMap and
+	 * applying the internal set of {@link LicensePolicyEnforcer} implementations on them,
+	 * and returning a mapping of Artifact keys to the boolean enforcement decision made.
+	 * 
+	 * @param licenseMap - a Consumer<LicenseMap>
+	 * @return final policy decision map on each artifact
+	 */
+	public Map<Artifact, LicensePolicyEnforcerResult> apply(final LicenseMap licenseMap) {
+		return apply(licenseMap.getLicenseMap());
+	}
+	
+	public void setEnforcers(final Set<LicensePolicyEnforcer> enforcers) {
+		this.enforcers = enforcers;
+	}
+
+	public Set<LicensePolicyEnforcer> getEnforcers() {
+		return enforcers;
+	}
+
+	public Set<LicensePolicy> getPolicies() {
+		return policies;
+	}
+
+    public LicensePolicyEnforcer<?> getDefaultPolicy() {
+		return defaultPolicy;
+	}
+
+	public void setDefaultPolicy(final LicensePolicyEnforcer defaultPolicy) {
+		this.defaultPolicy = defaultPolicy;
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.util.Collections;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
+
+/**
+ * Make policy decisions on a {@link Artifact} based on an {@link ArtifactFilter}.
+ * 
+ * @author Royce Remer
+ *
+ */
+public class ArtifactLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<Artifact> {
+	private ArtifactFilter filter;
+
+	public ArtifactLicensePolicyEnforcer(final LicensePolicy policy, final ArtifactFilter filter) {
+		super(policy);
+		this.filter = filter;
+	}
+	
+	public ArtifactLicensePolicyEnforcer(final LicensePolicy policy) {
+		super(policy);
+		this.filter = new StrictPatternIncludesArtifactFilter(Collections.singletonList(policy.getValue()));
+	}
+
+	@Override
+	public boolean apply(final Artifact target) {
+		final boolean matches = filter.include(target);
+		return getPolicy().getRule().isAllowed(matches);
+	}
+
+	@Override
+	public Class<?> getType() {
+		return Artifact.class;
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+/**
+ * A default deny ArtifactLicensePolicyEnforcer.
+ * 
+ * @author Royce Remer
+ *
+ */
+public class DefaultLicensePolicyEnforcer extends ArtifactLicensePolicyEnforcer {
+
+	public DefaultLicensePolicyEnforcer() {
+		super(new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, "*"));
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.License;
+
+/**
+ * To be implemented by different project/build-framework scanners presenting
+ * licenses of dependencies.
+ * 
+ * @author Royce Remer
+ *
+ */
+public interface LicenseMap {
+
+	Map<License, Set<Artifact>> getLicenseMap();
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+/**
+ * Expose message text to config and tests.
+ * 
+ * @author Royce Remer
+ *
+ */
+public interface LicenseMessage {
+	String WARN_POLICY_DENIED = "Some licenses were denied by policy:";
+	String INFO_LICENSE_IMPL = "Checking licenses in dependencies using";
+	String INFO_DEPS_DISCOVERED = "Discovered dependencies after filtering";
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import org.apache.maven.model.License;
+
+/**
+ * Make policy decisions on a {@link License} based on the license name.
+ * 
+ * @author Royce Remer
+ *
+ */
+public class LicenseNameLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
+
+	public LicenseNameLicensePolicyEnforcer(final LicensePolicy policy) {
+		super(policy);
+	}
+
+	@Override
+	public boolean apply(final License target) {
+		final Boolean matches = getPolicy().getValue().equals(target.getName());
+		return getPolicy().getRule().isAllowed(matches);
+	}
+
+	@Override
+	public Class<?> getType() {
+		return License.class;
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.util.Optional;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * A policy decision based on some matcher/value and type. Different policy
+ * enforcers should take this class as a constructor argument.
+ * 
+ * @author Royce Remer
+ *
+ */
+public class LicensePolicy {
+	public enum Type {
+		LICENSE_NAME, LICENSE_URL, ARTIFACT_PATTERN;
+	}
+
+	public enum Rule {
+		APPROVE(true), DENY(false);
+		boolean allowed;
+		Rule(final boolean allowed) {
+			this.allowed = allowed;
+		}
+		
+		/**
+		 * Get a boolean form of a rule.
+		 * @return
+		 */
+		public boolean getPredicate() {
+			return allowed;
+		}
+		
+		/**
+		 * Simple policy decision based on whether a matcher succeeded.
+		 * @param matched - boolean result of some matching operation.
+		 * @return
+		 */
+		public boolean isAllowed(final boolean matched) {
+			if ( matched && allowed) {
+				return true;
+			} else if ( !matched && !allowed) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+		
+		public static Rule valueOf(final boolean allowed) {
+			if (allowed) {
+				return APPROVE;
+			} else {
+				return DENY;
+			}
+		}
+	}
+
+	@Parameter
+	private Type type;
+	@Parameter
+	private Rule rule;
+	@Parameter
+	private String value;
+	
+	// only here for plexus container injection by maven
+	public LicensePolicy() {}
+
+	public LicensePolicy(final Rule rule, final Type type, final String value) {
+		this.setRule(rule);
+		this.setType(type);
+		this.setValue(value);
+	}
+	
+	@Override
+	public int hashCode() {
+		return 11 * (rule.hashCode() + type.hashCode() + value.hashCode());
+	}
+	
+	@Override
+	public boolean equals(final Object other) {
+		if (other == null) {
+			return false;
+		} else {
+			return (other.hashCode() == hashCode());
+		}
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public Rule getRule() {
+		return rule;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	private void setType(Type type) {
+		this.type = type;
+	}
+
+	private void setRule(Rule rule) {
+		this.rule = Optional.ofNullable(rule).orElse(Rule.DENY);
+	}
+
+	private void setValue(String value) {
+		this.value = Optional.ofNullable(value).orElse("");
+	}
+	
+	@Override
+	public String toString() {
+		return String.format("%s:%s:%s", getType(), getRule(), getValue());
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+/**
+ * Methods exposed by enforcer implementations using {@link LicensePolicy}.
+ * 
+ * @author Royce Remer
+ *
+ */
+public interface LicensePolicyEnforcer<T> {
+
+	public LicensePolicy getPolicy();
+	public boolean apply(final T target);
+	public Class<?> getType();
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResult.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResult.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.License;
+
+public class LicensePolicyEnforcerResult {
+
+	private final LicensePolicy policy;
+	private final License license;
+	private final Artifact artifact;
+	private final LicensePolicy.Rule ruling;
+	
+	public LicensePolicyEnforcerResult(final LicensePolicy policy, final License license, final Artifact artifact, final LicensePolicy.Rule ruling) {
+		this.policy = policy;
+		this.license = license;
+		this.artifact = artifact;
+		this.ruling = ruling;
+	}
+	
+	@Override
+	public int hashCode() {
+		return 11 * (policy.hashCode() + license.hashCode() + artifact.hashCode() + ruling.hashCode());
+	}
+	
+	@Override
+	public boolean equals(final Object other) {
+		if (other == null) {
+			return false;
+		} else {
+			return (other.hashCode() == hashCode());
+		}
+	}
+
+	public LicensePolicy getPolicy() {
+		return policy;
+	}
+
+	public Artifact getArtifact() {
+		return artifact;
+	}
+
+	public Boolean isAllowed() {
+		return ruling.getPredicate();
+	}
+	
+	public LicensePolicy.Rule getRuling() {
+		return ruling;
+	}
+
+	public License getLicense() {
+		return license;
+	}
+	
+	@Override
+	public String toString() {
+		return String.format("%s [%s] %s", getArtifact(), getLicense().getName(), getPolicy());
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import org.apache.maven.model.License;
+
+/**
+ * Make policy decisions on a {@link License} based on the license URL.
+ * 
+ * @author Royce Remer
+ *
+ */
+public class LicenseURLLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
+
+	public LicenseURLLicensePolicyEnforcer(final LicensePolicy policy) {
+		super(policy);
+	}
+
+	@Override
+	public boolean apply(final License target) {
+		final Boolean matches = getPolicy().getValue().equals(target.getUrl());
+		return getPolicy().getRule().isAllowed(matches);
+	}
+
+	@Override
+	public Class<?> getType() {
+		return License.class;
+	}
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2008-2021 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.License;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.DefaultProjectBuilder;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.internal.Maven31DependencyGraphBuilder;
+
+/**
+ * Helper class for building Artifact/License mappings from a maven project
+ * (multi module or single).
+ * 
+ * @author Royce Remer
+ *
+ */
+public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
+
+	private Set<MavenProject> projects;
+	private MavenSession session;
+	private DependencyGraphBuilder graph;
+	private ProjectBuilder projectBuilder;
+	private ProjectBuildingRequest buildingRequest;
+	private ArtifactFilter filter;
+	private Log log;
+
+	/**
+	 * @param projects       the Set of {@link MavenProject} to scan
+	 * @param graph          the {@link DependencyGraphBuilder} implementation
+	 * @param projectBuilder the maven {@link ProjectBuilder} implementation
+	 * @param filters        the list of {@link ArtifactFilter} to scope analysis to
+	 * @param log            the log to sync to
+	 */
+	public MavenProjectLicenses(final Set<MavenProject> projects, final DependencyGraphBuilder graph,
+			final ProjectBuilder projectBuilder, final ProjectBuildingRequest buildingRequest,
+			final ArtifactFilter filter, final Log log) {
+		this.setProjects(projects);
+		this.setBuildingRequest(buildingRequest);
+		this.setGraph(graph);
+		this.setFilter(filter);
+		this.setProjectBuilder(projectBuilder);
+		this.setLog(log);
+
+		log.info(String.format("%s %s", INFO_LICENSE_IMPL, this.getClass()));
+	}
+
+	/**
+	 * @param session        the current {@link MavenSession}
+	 * @param graph          the {@link DependencyGraphBuilder} implementation
+	 * @param projectBuilder the maven {@link ProjectBuilder} implementation
+	 * @param scope          String to filter artifacts to,
+	 *                       {@link org.apache.maven.artifact.ArtifactScopeEnum}
+	 * @param exclusions     List<String> of exclusion expressions,
+	 *                       {@link org.apache.maven.shared.artifact.filter.AbstractStrictPatternArtifactFilter}
+	 */
+	public MavenProjectLicenses(final MavenSession session, MavenProject project, final DependencyGraphBuilder graph,
+			final ProjectBuilder projectBuilder, final List<String> scopes, final Log log) {
+		this(Collections.singleton(project), graph, projectBuilder, getBuildingRequestWithDefaults(session),
+				new CumulativeScopeArtifactFilter(scopes), log);
+	}
+
+	private static ProjectBuildingRequest getBuildingRequestWithDefaults(final MavenSession session) {
+		ProjectBuildingRequest request;
+		if (session == null) {
+			request = new DefaultProjectBuildingRequest();
+		} else {
+			request = session.getProjectBuildingRequest();
+		}
+		return request;
+	}
+
+	/**
+	 * Return a set of licenses attributed to a single artifact.
+	 */
+	protected Set<License> getLicensesFromArtifact(final Artifact artifact) {
+		Set<License> licenses = new HashSet<License>();
+		try {
+			MavenProject project = getProjectBuilder().build(artifact, getBuildingRequest()).getProject();
+			licenses.addAll(project.getLicenses());
+		} catch (ProjectBuildingException ex) {
+			getLog().warn(String.format("Could not get project from dependency's artifact: %s", artifact.getFile()));
+		}
+
+		return licenses;
+	}
+
+	/**
+	 * Get mapping of Licenses to a set of artifacts presenting that license.
+	 * 
+	 * @param dependencies Set<Artifact> to collate License entries from
+	 * @return Map<License, Set<Artifact>> the same artifacts passed in, keyed by
+	 *         License.
+	 */
+	protected Map<License, Set<Artifact>> getLicenseMapFromArtifacts(final Set<Artifact> dependencies) {
+		final ConcurrentMap<License, Set<Artifact>> map = new ConcurrentHashMap<License, Set<Artifact>>();
+
+		// license:artifact is a many-to-many relationship.
+		// Each artifact may have several licenses.
+		// Each artifact may appear multiple times in the map.
+		dependencies.parallelStream().forEach(artifact -> getLicensesFromArtifact(artifact).forEach(license -> {
+			map.putIfAbsent(license, new HashSet<Artifact>());
+			Set<Artifact> artifacts = map.get(license);
+			artifacts.add(artifact);
+			map.put(license, artifacts);
+		}));
+
+		return map;
+	}
+
+	@Override
+	public Map<License, Set<Artifact>> getLicenseMap() {
+		return getLicenseMapFromArtifacts(getDependencies());
+	}
+
+	/**
+	 * Return the Set of all direct and transitive Artifact dependencies.
+	 */
+	private Set<Artifact> getDependencies() {
+		final Set<Artifact> artifacts = new HashSet<Artifact>();
+		final Set<DependencyNode> dependencies = new HashSet<DependencyNode>();
+
+		// build the set of maven dependencies for each module in the reactor (might
+		// only be the single one) and all its transitives
+		getLog().debug(String.format("Building dependency graphs for %d projects", getProjects().size()));
+		getProjects().parallelStream().forEach(project -> {
+			try {
+				dependencies.addAll(getGraph().buildDependencyGraph(project, getFilter()).getChildren());
+			} catch (DependencyGraphBuilderException ex) {
+				getLog().warn(
+						String.format("Could not get children from project %s, it's dependencies will not be checked!",
+								project.getId()));
+			}
+		});
+
+		// build the complete set of direct+transitive dependent artifacts in all
+		// modules in the reactor
+		dependencies.parallelStream().forEach(d -> artifacts.add(d.getArtifact()));
+		getLog().info(String.format("%s: %d", INFO_DEPS_DISCOVERED, dependencies.size()));
+
+		return artifacts;
+
+		// tempting, but does not resolve dependencies after the scope in which this
+		// plugin is invoked
+		// return project.getArtifacts();
+	}
+
+	private MavenSession getSession() {
+		return session;
+	}
+
+	private void setSession(MavenSession session) {
+		this.session = session;
+	}
+
+	protected Set<MavenProject> getProjects() {
+		return projects;
+	}
+
+	protected void setProjects(final Set<MavenProject> projects) {
+		this.projects = Optional.ofNullable(projects).orElse(new HashSet<MavenProject>());
+	}
+
+	private DependencyGraphBuilder getGraph() {
+		return graph;
+	}
+
+	private void setGraph(DependencyGraphBuilder graph) {
+		this.graph = Optional.ofNullable(graph).orElse(new Maven31DependencyGraphBuilder());
+	}
+
+	private ProjectBuilder getProjectBuilder() {
+		return projectBuilder;
+	}
+
+	private void setProjectBuilder(ProjectBuilder projectBuilder) {
+		this.projectBuilder = Optional.ofNullable(projectBuilder).orElse(new DefaultProjectBuilder());
+	}
+
+	private ArtifactFilter getFilter() {
+		return filter;
+	}
+
+	private void setFilter(ArtifactFilter filter) {
+		this.filter = filter;
+	}
+
+	private Log getLog() {
+		return log;
+	}
+
+	private void setLog(Log log) {
+		this.log = log;
+	}
+
+	private ProjectBuildingRequest getBuildingRequest() {
+		return buildingRequest;
+	}
+
+	protected void setBuildingRequest(final ProjectBuildingRequest buildingRequest) {
+		this.buildingRequest = Optional.ofNullable(buildingRequest).orElse(new DefaultProjectBuildingRequest());
+	}
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -15,19 +15,27 @@
  */
 package com.mycila.maven.plugin.license;
 
-import com.mycila.maven.plugin.license.util.FileUtils;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.junit.Test;
 
-import java.io.File;
-
-import static org.junit.Assert.assertEquals;
+import com.mycila.maven.plugin.license.util.FileUtils;
 
 /**
  * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 public final class CheckTest {
+	
+	@Test
+    public void test_defaultStubProject() throws Exception {
+        LicenseCheckMojo check = new LicenseCheckMojo();
+        check.project = new MavenProjectStub();
+        check.execute();
+    }	
 
     @Test
     public void test_line_wrapping() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcerTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcerTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class AggregateLicensePolicyEnforcerTest extends ArtifactLicensePolicyEnforcerTestBase {
+	LicenseMapData data;
+	Set<LicensePolicy> policies;
+	AggregateLicensePolicyEnforcer enforcer;
+	LicensePolicy defaultPolicy;
+	
+	@Before
+	public void setUp() {
+		data = new LicenseMapData();
+		policies = new HashSet<LicensePolicy>();
+		defaultPolicy = new DefaultLicensePolicyEnforcer().getPolicy();
+	}
+
+    @Test
+    public void test_defaultDeny() {
+    	final String description = "All artifacts should be denied by default.";
+    	
+    	data.put("com.example:example:jar:1.0.0", "", defaultPolicy, false);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	Map<Artifact, LicensePolicyEnforcerResult> expected = data.getExpected();
+    	Map<Artifact, LicensePolicyEnforcerResult> actual = enforcer.apply(data.getLicenseMap());
+    	
+    	assertEquals(description, expected, actual);
+    }
+    
+    @Test
+    public void test_allowedLicense() {
+    	final String description = "Artifacts with matching allowed licenses should be allowed, while unmatching should not.";
+    	final String license = "MIT";
+    	final LicensePolicy policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, license);
+    	
+    	data.put("com.example.allowed:boo:jar:1.0.0", license, policy, true);
+    	data.put("io.example:foobar:jar:2.1.0", license, policy, true);
+    	data.put("com.example.denied:evil:jar:0.0.1", "Evil license", defaultPolicy, false);
+    	data.put("com.example.denied:missing:jar:1.0.0", "", defaultPolicy, false);
+    	
+    	policies.add(policy);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	assertEquals(description, data.getExpected(), enforcer.apply(data.getLicenseMap()));
+    }
+    
+    @Test
+    public void test_allowedArtifact() {
+    	final String description = "Artifacts with an approved pattern should be allowed, while unmatching should not.";
+    	
+    	final LicensePolicy licensePolicy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "MIT");
+    	final LicensePolicy artifactPolicy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.ARTIFACT_PATTERN, "io.example*");
+    	
+    	data.put("com.example.allowed:boo:jar:1.0.0", "MIT", licensePolicy, true);
+    	data.put("io.example:foobar:jar:2.1.0", "Apache 2.0", artifactPolicy, true);
+    	data.put("com.example.denied:evil:jar:0.0.1", "Evil license", defaultPolicy, false);
+    	data.put("com.example.denied:missing:jar:1.0.0", "", defaultPolicy, false);
+    	
+    	policies.add(licensePolicy);
+    	policies.add(artifactPolicy);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	assertEquals(description, data.getExpected(), enforcer.apply(data.getLicenseMap()));
+    }
+    
+    @Test
+    public void test_multiAllowedLicense() {
+    	final String description = "Artifacts with matching allowed licenses should be allowed, even if there are multiple policies matching.";
+    	
+    	final LicensePolicy MITPolicy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "MIT");
+    	final LicensePolicy ASL2Policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "Apache 2.0");
+    	
+    	data.put("com.example.allowed:boo:jar:1.0.0", "MIT", MITPolicy, true);
+    	data.put("io.example:foobar:jar:2.1.0", "Apache 2.0", ASL2Policy, true);
+    	data.put("com.example.denied:evil:jar:0.0.1", "Evil license", defaultPolicy, false);
+    	data.put("com.example.denied:missing:jar:1.0.0", "", defaultPolicy, false);
+    	
+    	policies.add(MITPolicy);
+    	policies.add(ASL2Policy);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	assertEquals(description, data.getExpected(), enforcer.apply(data.getLicenseMap()));
+    }
+    
+    @Test
+    public void test_explicitDeny() {
+    	final String description = "Artifacts with matching allowed licenses but matching denied artifact should be denied.";
+    	final String license = "MIT";
+    	final String artifact = "com.example.denied:evil:jar:0.0.1";
+    	
+    	final LicensePolicy patternPolicy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, artifact);
+    	final LicensePolicy licensePolicy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, license);
+    	
+    	data.put("com.example.allowed:boo:jar:1.0.0", license, licensePolicy, true);
+    	data.put("io.example:foobar:jar:2.1.0", license, licensePolicy, true);
+    	data.put(artifact, license, patternPolicy, false);
+    	data.put("com.example.denied:missing:jar:1.0.0", "", defaultPolicy, false);
+    	
+    	policies.add(patternPolicy);
+    	policies.add(licensePolicy);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	assertEquals(description, data.getExpected(), enforcer.apply(data.getLicenseMap()));
+    }
+    
+    @Test
+    public void test_denyOverride() {
+    	final String description = "Conflicting policies should prefer deny rules.";
+    	
+    	final String license = "MIT";
+    	final LicensePolicy approvePolicy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, license);
+    	final LicensePolicy denyPolicy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.LICENSE_NAME, license);
+    	
+    	data.put("com.example.allowed:boo:jar:1.0.0", license, denyPolicy, false);
+    	
+    	policies.add(approvePolicy);
+    	policies.add(denyPolicy);
+    	enforcer = new AggregateLicensePolicyEnforcer(policies);
+    	
+    	assertEquals(description, data.getExpected(), enforcer.apply(data.getLicenseMap()));
+    }
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
+import org.junit.Test;
+
+public final class ArtifactLicensePolicyEnforcerTest extends ArtifactLicensePolicyEnforcerTestBase {
+	Artifact artifact;
+	LicensePolicy policy;
+	ArtifactLicensePolicyEnforcer enforcer;
+
+    @Test
+    public void test_explicitPatternAllowed() {
+    	final String description = "An artifact inclusion pattern explicitely matching with an allow rule should be allowed.";
+    	final String pattern = "com.example:example:jar:1.0.0";
+    	
+    	artifact = getArtifact(pattern);
+    	policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.ARTIFACT_PATTERN, pattern);
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, true, enforcer.apply(artifact));
+    }
+    
+    @Test
+    public void test_explicitPatternUnmatchedAllowed() {
+    	final String description = "An artifact inclusion pattern explicitely matching with an allow rule should deny non-matching artifacts.";
+    	final String pattern = "com.example:example:jar:1.0.0";
+    	
+    	artifact = getArtifact("com.example.subpackage:other-artifact:jar:1.0.0");
+    	policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.ARTIFACT_PATTERN, pattern);
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, false, enforcer.apply(artifact));
+    }
+    
+    @Test
+    public void test_explicitPatternUnmatchedDenied() {
+    	final String description = "An artifact inclusion pattern deny rule should allow unmatched artifacts.";
+    	
+    	artifact = getArtifact("com.example:example:jar:1.0.0");
+    	policy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, "com.example:example:jar:0.0.1");
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, true, enforcer.apply(artifact));
+    }
+
+    @Test
+    public void test_explicitPatternDenied() {
+    	final String description = "An artifact inclusion pattern explicitely matching with a deny rule should be denied.";
+    	final String pattern = "com.example:example:jar:1.0.0";
+    	
+    	artifact = getArtifact(pattern);
+    	policy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, pattern);
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, false, enforcer.apply(artifact));
+    }
+
+    @Test
+    public void test_greedyPatternAllowed() {
+    	final String description = "A greedy artifact inclusion pattern matching with an allow rule should be allowed.";
+    	final String gav = "com.example:example:jar:1.0.0";
+    	final String pattern = "com.example*";
+    	
+    	artifact = getArtifact(gav);
+    	policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.ARTIFACT_PATTERN, pattern);
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, true, enforcer.apply(artifact));
+    }
+    
+    @Test
+    public void test_greedyDeny() {
+    	final String description = "Greedy patterns with a deny rule should deny everything.";
+    	final String gav = "com.example:example:jar:1.0.0";
+    	final String pattern = "*";
+    	
+    	artifact = getArtifact(gav);
+    	policy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, null);
+    	enforcer = new ArtifactLicensePolicyEnforcer(policy);
+    	
+    	assertEquals(description, false, enforcer.apply(artifact));
+    }
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTestBase.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTestBase.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.License;
+
+/**
+ * Utility class for test setup methods related to this package.
+ * 
+ * @author Royce Remer
+ *
+ */
+class ArtifactLicensePolicyEnforcerTestBase {
+
+	/**
+	 * Helper method for easy {@link Artifact} generation.
+	 * @param gav - String with at least two separators of groupId:artifactId:type:artifactVersion.
+	 * @return
+	 */
+	protected Artifact getArtifact(final String gav) {
+		final String[] gavParts = gav.split(":");
+		return new DefaultArtifact(gavParts[0], gavParts[1], gavParts[3], "runtime", gavParts[2], "", new DefaultArtifactHandler());
+		
+	}
+	
+	/**
+	 * Helper method to get a license with set URL.
+	 * 
+	 * @param name
+	 * @return
+	 */
+	protected License getLicense(final URL url) {
+		final License license = new License();
+		license.setUrl(url.toString());;
+		return license;
+	}
+	
+	/**
+	 * Helper method to get a license with set name.
+	 * 
+	 * @param name
+	 * @return
+	 */
+	protected License getLicense(final String name) {
+		final License license = new License();
+		if (!"".equals(name)) {
+			license.setName(name);
+		}
+		return license;
+	}
+	
+	/**
+	 * Helper class for tracking test data related to license enforcement.
+	 * 
+	 * @author Royce Remer
+	 *
+	 */
+	protected class LicenseMapData implements LicenseMap {
+		Map<Artifact, LicensePolicyEnforcerResult> expected;
+		Map<License, Set<Artifact>> licenseMap;
+		
+		LicenseMapData() {
+			expected = new HashMap<Artifact, LicensePolicyEnforcerResult>();
+			licenseMap = new HashMap<License, Set<Artifact>>();
+		}
+		
+		void put(final String artifactCoordinates, final String licenseName, final LicensePolicy policy, final Boolean allowed) {
+			final Artifact artifact = getArtifact(artifactCoordinates);
+			final License license = getLicense(licenseName);
+			final Set<Artifact> artifacts = Optional.ofNullable(licenseMap.get(license)).orElse(new HashSet<Artifact>());
+			artifacts.add(artifact);
+			licenseMap.put(license, artifacts);
+			expected.put(artifact, new LicensePolicyEnforcerResult(policy, license, artifact, LicensePolicy.Rule.valueOf(allowed)));
+		}
+		
+		public Map<Artifact, LicensePolicyEnforcerResult> getExpected() {
+			return expected;
+		}
+		
+		@Override
+		public Map<License, Set<Artifact>> getLicenseMap(){
+			return licenseMap;
+		}
+	}
+	
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcerTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcerTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.maven.model.License;
+import org.junit.Test;
+
+public final class LicenseNameLicensePolicyEnforcerTest extends ArtifactLicensePolicyEnforcerTestBase {
+	License license;
+	LicensePolicy policy;
+	LicenseNameLicensePolicyEnforcer enforcer;
+
+	@Test
+	public void test_explicitLicenseAllowed() {
+		final String description = "An inclusion pattern explicitely matching with an allow rule should be allowed.";
+		final String pattern = "MIT";
+
+		license = getLicense(pattern);
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, pattern);
+		enforcer = new LicenseNameLicensePolicyEnforcer(policy);
+
+		assertEquals(description, true, enforcer.apply(license));
+	}
+	
+	@Test
+	public void test_nullDeny() {
+		final String description = "A missing license attribute should never match an allow rule.";
+		final String pattern = "MIT";
+
+		license = new License();
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, pattern);
+		enforcer = new LicenseNameLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+
+	@Test
+	public void test_defaultDeny() {
+		final String description = "An empty pattern should default deny unmatched license names.";
+
+		license = getLicense("MIT");
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, null);
+		enforcer = new LicenseNameLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+
+	@Test
+	public void test_explicitLicenseUnmatchedAllowed() {
+		final String description = "An explicit allow rule should deny unmatched license names.";
+
+		license = getLicense("something like an MIT license");
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "MIT");
+		enforcer = new LicenseNameLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResultTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResultTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.maven.model.License;
+import org.junit.Test;
+
+public final class LicensePolicyEnforcerResultTest extends ArtifactLicensePolicyEnforcerTestBase {
+
+    @Test
+    public void test_toString() {
+    	final String description = "The printable toString of a LicensePolicy should be useful/legible.";
+    	
+    	final License license = getLicense("my license");
+    	license.setUrl("https://localhost/mylicense");
+    	
+    	final LicensePolicy policy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.LICENSE_URL, license.getUrl());
+    	final LicensePolicyEnforcerResult result = new LicensePolicyEnforcerResult(policy, license, getArtifact("com.example:foobar:jar:1.2.3"), LicensePolicy.Rule.DENY);
+    	final String expected = "com.example:foobar:jar:1.2.3:runtime [my license] LICENSE_URL:DENY:https://localhost/mylicense";
+    	
+    	assertEquals(description, expected, result.toString());
+    }
+    
+    @Test
+    public void test_equals() {
+    	final String description = "To results with identical fields should be equal.";
+    	
+    	final License license = getLicense("");
+    	
+    	final LicensePolicy policy = new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.LICENSE_NAME, license.getName());
+    	final LicensePolicyEnforcerResult resultOne = new LicensePolicyEnforcerResult(policy, license, getArtifact("com.example:foobar:jar:1.2.3"), LicensePolicy.Rule.DENY);
+    	final LicensePolicyEnforcerResult resultTwo = new LicensePolicyEnforcerResult(policy, license, getArtifact("com.example:foobar:jar:1.2.3"), LicensePolicy.Rule.DENY);
+    	
+    	assertEquals(description, resultOne, resultTwo);
+    }
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class LicensePolicyTest {
+
+    @Test
+    public void test_toString() {
+    	final String description = "The printable toString of a LicensePolicy should be useful/legible.";
+    	
+    	final LicensePolicy policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "example");
+    	final String expected = "LICENSE_NAME:APPROVE:example";
+    	
+    	assertEquals(description, expected, policy.toString());
+    }
+    
+    @Test
+    public void test_equals() {
+    	final String description = "Two policies with identical fields should be equal.";
+    	
+    	final LicensePolicy policyOne = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "example");
+    	final LicensePolicy policyTwo = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "example");
+    	
+    	assertEquals(description, policyOne, policyTwo);
+    }
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcerTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcerTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.maven.model.License;
+import org.junit.Test;
+
+public final class LicenseURLLicensePolicyEnforcerTest extends ArtifactLicensePolicyEnforcerTestBase {
+	License license;
+	LicensePolicy policy;
+	LicenseURLLicensePolicyEnforcer enforcer;
+
+	@Test
+	public void test_explicitLicenseAllowed() throws MalformedURLException {
+		final String description = "An inclusion pattern explicitely matching with an allow rule should be allowed.";
+		final String pattern = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+		license = getLicense(new URL(pattern));
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, pattern);
+		enforcer = new LicenseURLLicensePolicyEnforcer(policy);
+
+		assertEquals(description, true, enforcer.apply(license));
+	}
+	
+	@Test
+	public void test_nullDeny() {
+		final String description = "A missing license attribute should never match an allow rule.";
+		final String pattern = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+
+		license = new License();
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, pattern);
+		enforcer = new LicenseURLLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+
+	@Test
+	public void test_defaultDeny() throws MalformedURLException {
+		final String description = "An empty pattern should default deny unmatched license URLs.";
+
+		license = getLicense(new URL("https://localhost/my-license"));
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, null);
+		enforcer = new LicenseURLLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+
+	@Test
+	public void test_explicitLicenseUnmatchedAllowed() throws MalformedURLException {
+		final String description = "An explicit allow rule should deny unmatched license URLs.";
+
+		license = getLicense(new URL("https://localhost/my-license"));
+		policy = new LicensePolicy(LicensePolicy.Rule.APPROVE, LicensePolicy.Type.LICENSE_NAME, "https://www.apache.org/licenses/LICENSE-2.0.txt");
+		enforcer = new LicenseURLLicensePolicyEnforcer(policy);
+
+		assertEquals(description, false, enforcer.apply(license));
+	}
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.dependencies;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.io.Files;
+
+/**
+ * We use {@link Verifier} here for mvn executions, mainly so:
+ * a) we can verify a few cases that the invoker method make really difficult (I'd like to step-through with my IDE)
+ * b) the test harness method requires creating a custom Artifact resolver, as the dependencGraphBuilder Component will
+ *    not provide a usable bean, and we would need extensive mocking to override data for specific cases
+ * c) it's a lot faster than maven-invoker-plugin
+ * ... good overview of similar woes {@link https://khmarbaise.github.io/maven-it-extension/itf-documentation/background/background.html}
+ * 
+ * @author Royce Remer
+ *
+ */
+public final class MavenProjectLicensesIT {
+	
+	File source;
+	String target;
+	String phase;
+	Map<String, String> env;
+	
+	@Rule
+	public TemporaryFolder workspace = new TemporaryFolder();
+	final String sourcePrefix = "src/test/resources/config/";
+	final String resource = "/pom.xml";
+	
+	@Before
+	public void setUp() {
+		// your maven may be on a different path, they'll append '/bin/mvn' to it
+		System.setProperty("maven.home", "/usr/local");
+		
+		this.target = workspace.getRoot().getAbsolutePath();
+		this.env = Collections.singletonMap("LICENSE_PLUGIN_VERSION", this.getClass().getPackage().getImplementationVersion());
+		this.phase = "verify";
+	}
+	
+	private boolean hasLogLine(final String logline) {
+		Optional<Verifier> verifier;
+		try {
+			verifier = Optional.of(new Verifier(target));
+		} catch (Exception ex) {
+			// project didn't even build, this is a test or test resource error
+			return false;
+		}
+		
+		try {
+			verifier.get().executeGoal(phase, env);
+		} catch (VerificationException e) {
+			// potential purposeful MojoExecutionException (hidden in stack)
+			try {
+				verifier.get().verifyTextInLog(logline);
+				return true;
+			} catch (VerificationException e1) {}
+		}
+		
+		// legit test failure
+		return false;
+	}
+	
+	/**
+	 * Helper method to sync test resources to a temporary folder for execution.
+	 * @param dir - String relative path to {@link sourcePrefix} to copy from.
+	 * @throws IOException
+	 */
+	private void syncTarget(final String dir) throws IOException {
+		source = new File(sourcePrefix + dir + resource);
+		final File syncTarget = new File(target + resource);
+		Files.copy(source, syncTarget);
+	}
+		
+    @Test
+    public void test_null() throws IOException {
+    	final String description = "A project with enforcement enabled but nothing in scope should find zero dependencies";
+    	syncTarget("null");
+    	
+    	assertEquals(description, true, hasLogLine(MavenProjectLicenses.INFO_DEPS_DISCOVERED + ": 1"));
+    }
+    
+    @Test
+    public void test_deny() throws IOException {
+    	final String description = "A project with enforcement enabled and dependencies in scope under default deny policy should fail.";
+    	syncTarget("deny");
+    	
+    	assertEquals(description, true, hasLogLine(MavenProjectLicenses.WARN_POLICY_DENIED));
+    }
+    
+    @Test
+    public void test_approved() throws IOException {
+    	final String description = "A project with allow policy and a single dependency should succeed.";
+    	syncTarget("approve");
+    	
+    	assertEquals(description, true, hasLogLine(MavenProjectLicenses.INFO_DEPS_DISCOVERED + ": 1"));
+    }
+}

--- a/license-maven-plugin/src/test/resources/config/approve/pom.xml
+++ b/license-maven-plugin/src/test/resources/config/approve/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>dependencies-enforce</artifactId>
+    <version>1.0.0</version>
+
+    <name>Enforce licenses in dependencies</name>
+    <description>Integration Test for validating enforcement of licenses in dependencies</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${env.LICENSE_PLUGIN_VERSION}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dependencyEnforce>true</dependencyEnforce>
+                    <dependencyScopes>
+                        <dependencyScope>test</dependencyScope>
+                    </dependencyScopes>
+                    <dependencyPolicies>
+                        <dependencyPolicy>
+                            <type>LICENSE_NAME</type>
+                            <rule>APPROVE</rule>
+                            <value>Eclipse Public License 1.0</value>
+                        </dependencyPolicy>
+                    </dependencyPolicies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/license-maven-plugin/src/test/resources/config/deny/pom.xml
+++ b/license-maven-plugin/src/test/resources/config/deny/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>dependencies-enforce</artifactId>
+    <version>1.0.0</version>
+
+    <name>Enforce licenses in dependencies</name>
+    <description>Integration Test for validating enforcement of licenses in dependencies</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${env.LICENSE_PLUGIN_VERSION}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dependencyEnforce>true</dependencyEnforce>
+                    <dependencyScopes>
+                        <dependencyScope>test</dependencyScope>
+                    </dependencyScopes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/test/resources/config/null/pom.xml
+++ b/license-maven-plugin/src/test/resources/config/null/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>dependencies-enforce</artifactId>
+    <version>1.0.0</version>
+
+    <name>Enforce licenses in dependencies</name>
+    <description>Integration Test for validating enforcement of licenses in dependencies</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${env.LICENSE_PLUGIN_VERSION}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dependencyEnforce>true</dependencyEnforce>
+                    <!-- shouldn't find anything to complain about -->
+                    <dependencyScopes>
+                        <dependencyScope>runtime</dependencyScope>
+                        <dependencyScope>compile</dependencyScope>
+                    </dependencyScopes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <jdk.version>1.8</jdk.version>
         <source.encoding>UTF-8</source.encoding>
         <mycila.github.name>license-maven-plugin</mycila.github.name>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <modules>
@@ -67,9 +67,22 @@
                 <version>3.6.3</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>3.6.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>3.6.0</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- (mistakenly?) provides version 3.0,
+                             explicit dependency aligns with maven-core -->
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-artifact</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.mycila</groupId>


### PR DESCRIPTION
Sorry for the massive PR, the complexity of #203 eluded me and I just kept coding, should have circled back a few times with you first @mathieucarbou .

Some overview:
* this code meets my immediate needs within my company, so I consider it ready to merge (sans any feedback changes you have me make)
* everything is implemented within the same `check` goal, however I've setup my integration tests and primary classes to support a `report` goal which we can do in a separate review
* I deviated slightly from this project's current maven-invoker-plugin approach to running integration tests. I wanted a few primary cases to be covered outside my unit tests, and the invoker method was really slow and impossible to debug, so I'm `org.apache.maven.it.Verifier` within junit to execute integration tests against projects in `src/test/resources/config`, hope that makes sense. Happy to refactor the existing integration tests if you like this method.
* all the logic for dependency discovery is currently within `MavenProjectLicenses`, as I was thinking about future cases where we may invoke this maven plugin to performe license enforcement on other languages/frameworks (gradle+java, python, whatever). I haven't implemented a config-driven factory for this, as it seemed a little premature and obtuse, but that was my thinking down-the-line

And one question for you:
Would you like me to put some documentation in `src/site`? Or we maintain a wiki? The parameters I've added are javadoc, but some common configuration examples would likely be helpful to others who don't know to go digging in this projects test resources