### PR TITLE
Support injecting Copyright Years based on file existence

### DIFF
--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
@@ -35,6 +35,7 @@ public class CopyrightRangeProvider extends GitPropertiesProvider implements Pro
 
   public static final String COPYRIGHT_LAST_YEAR_KEY = "license.git.copyrightLastYear";
   public static final String COPYRIGHT_CREATION_YEAR_KEY = "license.git.copyrightCreationYear";
+  public static final String COPYRIGHT_EXISTENCE_YEARS_KEY = "license.git.copyrightExistenceYears";
   public static final String COPYRIGHT_YEARS_KEY = "license.git.copyrightYears";
   public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
 
@@ -44,17 +45,19 @@ public class CopyrightRangeProvider extends GitPropertiesProvider implements Pro
   }
 
   /**
-   * Returns an unmodifiable map containing the three entries {@value #COPYRIGHT_LAST_YEAR_KEY}, {@value #COPYRIGHT_YEARS_KEY},
-   * and {@value #COPYRIGHT_CREATION_YEAR_KEY}, whose values are set based on inspecting git history.
+   * Returns an unmodifiable map containing the following entries, whose values are set based on inspecting git history.
    *
    * <ul>
    * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
-   * modified the supplied {@code document}.
+   * modified the supplied {@code document}.</li>
    * <li>{@value #COPYRIGHT_YEARS_KEY} key stores the range from {@value #INCEPTION_YEAR_KEY} value to
    * {@value #COPYRIGHT_LAST_YEAR_KEY} value. If both values a equal, only the {@value #INCEPTION_YEAR_KEY} value is
-   * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000 - 2010"}.
+   * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000-2010"}.</li>
    * <li>{@value #COPYRIGHT_CREATION_YEAR_KEY} key stores the year from the committer date of the first git commit for
-   * the supplied {@code document}.
+   * the supplied {@code document}.</li>
+   * <li>{@value #COPYRIGHT_EXISTENCE_YEARS_KEY} key stores the range from {@value #COPYRIGHT_CREATION_YEAR_KEY} value to 
+   * {@value #COPYRIGHT_LAST_YEAR_KEY} value.  If both values are equal only the {@value #COPYRIGHT_CREATION_YEAR_KEY} is returned;
+   * otherwise, the two values are combined using dash, so that the result is e.g. {@code "2005-2010"}.</li>
    * </ul>
    * The {@value #INCEPTION_YEAR_KEY} value is read from the supplied properties and it must available. Otherwise a
    * {@link RuntimeException} is thrown.
@@ -88,6 +91,15 @@ public class CopyrightRangeProvider extends GitPropertiesProvider implements Pro
 
       int copyrightStart = gitLookup.getYearOfCreation(document.getFile());
       result.put(COPYRIGHT_CREATION_YEAR_KEY, Integer.toString(copyrightStart));
+      
+      final String copyrightExistenceYears;
+      if (copyrightStart >= copyrightEnd) {
+          copyrightExistenceYears = Integer.toString(copyrightStart);
+      } else {
+          copyrightExistenceYears = copyrightStart + "-" + copyrightEnd;
+      }
+      result.put(COPYRIGHT_EXISTENCE_YEARS_KEY, copyrightExistenceYears);
+      
       return Collections.unmodifiableMap(result);
     } catch (Exception e) {
       throw new RuntimeException("Could not compute the year of the last git commit for file "

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -142,10 +142,6 @@ public class GitLookup {
   int getYearOfCreation(File file) throws IOException, GitAPIException {
     String repoRelativePath = pathResolver.relativize(file);
 
-    if (isFileModifiedOrUnstaged(repoRelativePath)) {
-      return getCurrentYear();
-    }
-
     int commitYear = 0;
     RevWalk walk = getGitRevWalk(repoRelativePath, true);
     Iterator<RevCommit> iterator = walk.iterator();
@@ -154,6 +150,12 @@ public class GitLookup {
       commitYear = getYearFromCommit(commit);
     }
     walk.dispose();
+    
+    // If we couldn't find a creation year from Git assume newly created file
+    if (commitYear == 0) {
+        return getCurrentYear();
+      }
+    
     return commitYear;
   }
 

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
@@ -41,25 +41,27 @@ public class CopyrightRangeProviderTest {
   public void copyrightRange() {
     CopyrightRangeProvider provider = new CopyrightRangeProvider();
 
-    assertRange(provider, "dir1/file1.txt", "2000", "2006", "1999-2006");
-    assertRange(provider, "dir2/file2.txt", "2007", "2007", "1999-2007");
-    assertRange(provider, "dir1/file3.txt", "2009", "2009", "1999-2009");
-    assertRange(provider, "dir2/file4.txt", "1999", "1999", "1999");
+    assertRange(provider, "dir1/file1.txt", "2000", "2006", "1999-2006", "2000-2006");
+    assertRange(provider, "dir2/file2.txt", "2007", "2007", "1999-2007", "2007");
+    assertRange(provider, "dir1/file3.txt", "2009", "2009", "1999-2009", "2009");
+    assertRange(provider, "dir2/file4.txt", "1999", "1999", "1999", "1999");
 
     /* The last change of file4.txt in git history is in 1999
      * but the inception year is 2000
      * and we do not want the range to go back (2000-1999)
-     * so in this case we expect just 2000 */
-    assertRange(provider, "dir2/file4.txt", "2000", "1999", "1999", "2000");
+     * so in this case we expect just 2000
+     * However for existence years always report the actual year regardless
+     * of the inception year so expect 1999 for that */
+    assertRange(provider, "dir2/file4.txt", "2000", "1999", "1999", "2000", "1999");
 
   }
 
-  private void assertRange(CopyrightRangeProvider provider, String path, String copyrightStart, String copyrightEnd, String copyrightRange) {
-    assertRange(provider, path, "1999", copyrightStart, copyrightEnd, copyrightRange);
+  private void assertRange(CopyrightRangeProvider provider, String path, String copyrightStart, String copyrightEnd, String copyrightRange, String copyrightExistence) {
+    assertRange(provider, path, "1999", copyrightStart, copyrightEnd, copyrightRange, copyrightExistence);
   }
 
   private void assertRange(CopyrightRangeProvider provider, String path, String inceptionYear,
-                           String copyrightStart, String copyrightEnd, String copyrightRange) {
+                           String copyrightStart, String copyrightEnd, String copyrightRange, String copyrightExistence) {
     Properties props = new Properties();
     props.put(CopyrightRangeProvider.INCEPTION_YEAR_KEY, inceptionYear);
 
@@ -70,6 +72,7 @@ public class CopyrightRangeProviderTest {
     expected.put(CopyrightRangeProvider.COPYRIGHT_CREATION_YEAR_KEY, copyrightStart);
     expected.put(CopyrightRangeProvider.COPYRIGHT_LAST_YEAR_KEY, copyrightEnd);
     expected.put(CopyrightRangeProvider.COPYRIGHT_YEARS_KEY, copyrightRange);
+    expected.put(CopyrightRangeProvider.COPYRIGHT_EXISTENCE_YEARS_KEY, copyrightExistence);
     Assert.assertEquals("for file '" + path + "': ", expected, actual);
 
   }


### PR DESCRIPTION
For some Copyright policies the years in the header should reflect only
the existence of that file not the project as a whole.  While this can
be achieved by using `${license.git.copyrightCreationYear}` and
`${license.git.copyrightLastYear}` in the header template you end up
generating awkward headers for some files e.g. `2021-2021`.  And you
cannot use `${license.git.copyrightYears}` for this use case because that
will use the project inception year giving you something like `2019-2021`.

This commit adds a new calculated property
`${license.git.copyrightExistenceYears}` which provides this information
and may be used in header templates where this behaviour is desired.  This
should basically address the issue described in adobe/S3Mock#241 

It also fixes a bug in `GitLookup` whereby if you had modified the file
it would incorrectly calculate the year range (because the creation year
was always defaulted to current year for modified files) and falsely flag
a license header as missing (or reformat unncessarily).