### PR TITLE
[pom] Fix relative path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <groupId>com.mycila</groupId>
     <artifactId>mycila-pom</artifactId>
     <version>9</version>
+    <relativePath />
   </parent>
 
   <artifactId>license-maven-plugin-parent</artifactId>


### PR DESCRIPTION
This must always be set if the folder above is not part of same project.  This causes it to throw warnings if broader project attached, just wastes a check and ultimately it should be looking in the caching system and remote instead.