### PR TITLE
Suppress resource leak warning for instantiated Git object

### DIFF
--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -186,6 +186,7 @@ public class GitLookup {
   }
 
   private boolean isFileModifiedOrUnstaged(String repoRelativePath) throws GitAPIException {
+    @SuppressWarnings("resource")
     Status status = new Git(repository).status().addPath(repoRelativePath).call();
     return !status.isClean();
   }


### PR DESCRIPTION
The `Git` class implements `AutoCloseable` which triggers warnings that the resource is not closed.  

However, the `close()` method documents that closure of the underlying repo does not occur with this particular usage and would be a no-op.  Adding a suppress warning notation helps indicate that we (think we) know what we're (not) doing.