### PR TITLE
Skip if only header difference is copyright first year

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -356,6 +356,13 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   public boolean skipExistingHeaders = false;
 
   /**
+   * Skip the formatting of files which already contain a detected header in which
+   * the only difference is the first year of the copyright.
+   */
+  @Parameter(property = "license.skipExistingCopyrightFirstYear", defaultValue = "false")
+  public boolean skipExistingCopyrightFirstYear;
+
+  /**
    * When enforcing licenses on dependencies, exclude all but these scopes.
    */
   @Parameter(property = "license.dependencies.scope", required = true, defaultValue = "runtime")
@@ -632,12 +639,12 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
             callback.onUnknownFile(document, h);
           } else if (document.is(h)) {
             debug("Skipping header file: %s", document.getFilePath());
-          } else if (document.hasHeader(h, strictCheck)) {
+          } else if (document.hasHeader(h, strictCheck, skipExistingCopyrightFirstYear)) {
             callback.onExistingHeader(document, h);
           } else {
             boolean headerFound = false;
             for (final Header validHeader : validHeaders) {
-              headerFound = document.hasHeader(validHeader, strictCheck);
+              headerFound = document.hasHeader(validHeader, strictCheck, skipExistingCopyrightFirstYear);
               if (headerFound) {
                 callback.onExistingHeader(document, h);
                 break;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
@@ -180,6 +180,17 @@ public final class Header {
     return isMatchForText(expected, fileHeader, headerDefinition, unix);
   }
 
+  public boolean isMatchForTextKeepingFirstYear(Document d, HeaderDefinition headerDefinition, boolean unix, String encoding) throws IOException {
+    String fileHeader = readFirstLines(d.getFile(), getLineCount() + 10, encoding).replaceAll(" *\r?\n", "\n");
+    String existingCopyrightFirstYear = Document.getCopyrightFirstYear(fileHeader);
+    if (existingCopyrightFirstYear == null) {
+      return isMatchForText(d, headerDefinition, unix, encoding);
+    }
+    String expected = buildForDefinition(headerDefinition, unix);
+    expected = Document.replaceCopyrightFirstYear(d.mergeProperties(expected), existingCopyrightFirstYear);
+    return isMatchForText(expected, fileHeader, headerDefinition, unix);
+  }
+
   public String applyDefinitionAndSections(HeaderDefinition headerDefinition, boolean unix) {
 
     String expected = buildForDefinition(headerDefinition, unix);


### PR DESCRIPTION
Some users have known Copyright start dates that do not match existing substitutions such as the project inception date or file creation date.  These may include files moved between packages that are not tracked by git/svn or files copied from another project the committer authored.

Alternately, some users may have used a full depth history and this plugin to generate copyright dates, but want CI executions with shallow history to ignore the (newer) calculated start dates for the oldest commits, while still calculating new end dates for the changed files.

This change introduces a new property, `skipExistingCopyrightFirstYear` which defaults to `false` (no change from existing behavior).  If set true, the plugin will take the following steps when checking or formatting license headers:
1. Extract the first consecutive 4 digits which follow the word "copyright" (case insensitive) in the file being checked.
2. Replace the first four digits after "copyright" in the expected copyright header with the existing copyright year.
3. Continue with normal header checking steps.

Submitting as a draft for comment, as I still need to handle the single-year-range edge case, but figured I'd get some feedback before adding that extra effort.