### PR TITLE
[pom] Per maven standards, make certain artifacts provided

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -140,10 +140,22 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
         <version>3.8.5</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-model</artifactId>
+        <version>3.8.5</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
         <version>3.6.4</version>


### PR DESCRIPTION
- added two that need to be provided that are compile in usage.  This is now required upon backport to maven plugin plugin that throws warnings to the same.  These specific libraries ship with maven and therefore are not needed to repeat.  This keeps m2 repository cleaner.