### PR TITLE
Restore test runs, add jacoco, and fix resulting broken tests

### DIFF
--- a/license-maven-plugin-git/pom.xml
+++ b/license-maven-plugin-git/pom.xml
@@ -39,6 +39,10 @@
     </site>
   </distributionManagement>
 
+  <properties>
+    <jacoco.minimum.coverage>0.81</jacoco.minimum.coverage>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.mycila</groupId>

--- a/license-maven-plugin-git/pom.xml
+++ b/license-maven-plugin-git/pom.xml
@@ -40,7 +40,7 @@
   </distributionManagement>
 
   <properties>
-    <jacoco.minimum.coverage>0.81</jacoco.minimum.coverage>
+    <jacoco.minimum.coverage>0.80</jacoco.minimum.coverage>
   </properties>
 
   <dependencies>

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
@@ -21,7 +21,6 @@ import com.mycila.maven.plugin.license.document.Document;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -64,7 +63,7 @@ class CopyrightAuthorProviderTest {
   }
 
   private static Document newDocument(String relativePath) {
-    Path path = Paths.get(gitRepoRoot.toAbsolutePath() + File.separator
+    Path path = Paths.get(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar));
     return new Document(path.toFile(), null, "utf-8", new String[0], null);
   }
@@ -72,10 +71,9 @@ class CopyrightAuthorProviderTest {
   @BeforeAll
   static void beforeClass() throws IOException {
     URL url = GitLookupTest.class.getResource("git-test-repo.zip");
-    Path unzipDestination = tempFolder.toPath();
-    gitRepoRoot = Files.createDirectory(unzipDestination);
+    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
 
-    GitLookupTest.unzip(url, unzipDestination);
+    GitLookupTest.unzip(url, tempFolder.toPath());
   }
 
 }

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
@@ -21,7 +21,6 @@ import com.mycila.maven.plugin.license.document.Document;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -36,7 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
-public class CopyrightRangeProviderTest {
+class CopyrightRangeProviderTest {
 
   private static Path gitRepoRoot;
 
@@ -44,7 +43,7 @@ public class CopyrightRangeProviderTest {
   static File tempFolder;
 
   @Test
-  public void copyrightRange() {
+  void copyrightRange() {
     CopyrightRangeProvider provider = new CopyrightRangeProvider();
 
     assertRange(provider, "dir1/file1.txt", "2000", "2006", "1999-2006", "2000-2006");
@@ -84,18 +83,17 @@ public class CopyrightRangeProviderTest {
   }
 
   private static Document newDocument(String relativePath) {
-    Path path = Paths.get(gitRepoRoot.toAbsolutePath() + File.separator
+    Path path = Paths.get(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar));
     return new Document(path.toFile(), null, "utf-8", new String[0], null);
   }
 
   @BeforeAll
-  public static void beforeClass() throws IOException {
+  static void beforeClass() throws IOException {
     URL url = GitLookupTest.class.getResource("git-test-repo.zip");
-    Path unzipDestination = tempFolder.toPath();
-    gitRepoRoot = Files.createDirectory(unzipDestination);
+    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
 
-    GitLookupTest.unzip(url, unzipDestination);
+    GitLookupTest.unzip(url, tempFolder.toPath());
   }
 
 }

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
@@ -29,7 +29,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Calendar;
@@ -40,7 +39,7 @@ import java.util.zip.ZipInputStream;
 /**
  * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
-public class GitLookupTest {
+class GitLookupTest {
 
   private static Path gitRepoRoot;
 
@@ -48,12 +47,10 @@ public class GitLookupTest {
   static File tempFolder;
 
   @BeforeAll
-  public static void beforeClass() throws IOException {
+  static void beforeClass() throws IOException {
     URL url = GitLookupTest.class.getResource("git-test-repo.zip");
-    Path unzipDestination = tempFolder.toPath();
-    gitRepoRoot = Files.createDirectory(unzipDestination);
-
-    unzip(url, unzipDestination);
+    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
+    unzip(url, tempFolder.toPath());
   }
 
   static void unzip(URL url, Path unzipDestination) throws IOException {
@@ -92,7 +89,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void modified() throws GitAPIException, IOException {
+  void modified() throws GitAPIException, IOException {
     assertLastChange(newAuthorLookup(), "dir1/file1.txt", 2006);
     assertLastChange(newCommitterLookup(), "dir1/file1.txt", 2006);
 
@@ -101,7 +98,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void justCreated() throws GitAPIException, IOException {
+  void justCreated() throws GitAPIException, IOException {
     assertLastChange(newAuthorLookup(), "dir2/file2.txt", 2007);
     assertLastChange(newCommitterLookup(), "dir2/file2.txt", 2007);
 
@@ -110,7 +107,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void moved() throws GitAPIException, IOException {
+  void moved() throws GitAPIException, IOException {
     assertLastChange(newAuthorLookup(), "dir1/file3.txt", 2009);
     assertLastChange(newCommitterLookup(), "dir1/file3.txt", 2010);
 
@@ -120,7 +117,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void newUnstaged() throws GitAPIException, IOException {
+  void newUnstaged() throws GitAPIException, IOException {
     int currentYear = getCurrentGmtYear();
     assertLastChange(newAuthorLookup(), "dir1/file5.txt", currentYear);
     assertLastChange(newCommitterLookup(), "dir1/file5.txt", currentYear);
@@ -130,7 +127,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void newStaged() throws GitAPIException, IOException {
+  void newStaged() throws GitAPIException, IOException {
     int currentYear = getCurrentGmtYear();
     assertLastChange(newAuthorLookup(), "dir1/file6.txt", currentYear);
     assertLastChange(newCommitterLookup(), "dir1/file6.txt", currentYear);
@@ -149,7 +146,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void reuseProvider() throws GitAPIException, IOException {
+  void reuseProvider() throws GitAPIException, IOException {
     GitLookup provider = newAuthorLookup();
     assertLastChange(provider, "dir1/file1.txt", 2006);
     assertLastChange(provider, "dir2/file2.txt", 2007);
@@ -157,7 +154,7 @@ public class GitLookupTest {
   }
 
   @Test
-  public void timezone() throws GitAPIException, IOException {
+  void timezone() throws GitAPIException, IOException {
     try {
       new GitLookup(gitRepoRoot.toFile(), DateSource.AUTHOR, TimeZone.getTimeZone("GMT"), 10);
       Assertions.fail("RuntimeException expected");
@@ -196,14 +193,14 @@ public class GitLookupTest {
 
   private void assertLastChange(GitLookup provider, String relativePath, int expected) throws
       GitAPIException, IOException {
-    int actual = provider.getYearOfLastChange(Paths.get(gitRepoRoot.toAbsolutePath() + File.separator
+    int actual = provider.getYearOfLastChange(Paths.get(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar)).toFile());
     Assertions.assertEquals(expected, actual);
   }
 
   private void assertCreation(GitLookup provider, String relativePath, int expected) throws
       GitAPIException, IOException {
-    int actual = provider.getYearOfCreation(Paths.get(gitRepoRoot.toAbsolutePath() + File.separator
+    int actual = provider.getYearOfCreation(Paths.get(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar)).toFile());
     Assertions.assertEquals(expected, actual);
   }

--- a/license-maven-plugin-svn/pom.xml
+++ b/license-maven-plugin-svn/pom.xml
@@ -37,6 +37,10 @@
     </site>
   </distributionManagement>
 
+  <properties>
+    <jacoco.minimum.coverage>0.00</jacoco.minimum.coverage>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.mycila</groupId>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -40,6 +40,10 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <jacoco.minimum.coverage>0.77</jacoco.minimum.coverage>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -196,6 +196,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>5.8.2</version>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -41,7 +41,7 @@
   </scm>
 
   <properties>
-    <jacoco.minimum.coverage>0.77</jacoco.minimum.coverage>
+    <jacoco.minimum.coverage>0.76</jacoco.minimum.coverage>
   </properties>
 
   <build>

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.mycila.maven.plugin.license.header.HeaderType.APOSTROPHE_STYLE;
 import static com.mycila.maven.plugin.license.header.HeaderType.ASCIIDOC_STYLE;
@@ -74,7 +75,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 class CompleteMojoTest {
 
-  private static Iterable<Object[]> parameters() {
+  private static Stream<Object[]> parameters() {
     final List<Object[]> parameters = asList(new Object[][]{
         {ASCIIDOC_STYLE, "adoc"},
         {MVEL_STYLE, "mv"},
@@ -120,20 +121,12 @@ class CompleteMojoTest {
       Assertions.fail("Missing test cases: " + set);
     }
 
-    return parameters;
-  }
-
-  private final String extension;
-  private final HeaderType headerType;
-
-  public CompleteMojoTest(HeaderType headerType, String extension) {
-    this.extension = extension;
-    this.headerType = headerType;
+    return parameters.stream();
   }
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void test_add(String name, HeaderType headerType) throws Exception {
+  void test_add(HeaderType headerType, String extension) throws Exception {
     File tmp = new File("target/test/complete/" + headerType + "/test_add");
     FileUtils.copyFilesToFolder(new File("src/test/resources/complete/" + headerType), tmp);
 
@@ -153,7 +146,7 @@ class CompleteMojoTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void test_update(String name) throws Exception {
+  void test_update(HeaderType headerType, String extension) throws Exception {
     File tmp = new File("target/test/complete/" + headerType + "/test_update");
     FileUtils.copyFilesToFolder(new File("src/test/resources/complete/" + headerType), tmp);
 
@@ -182,7 +175,7 @@ class CompleteMojoTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void test_remove(String name) throws Exception {
+  void test_remove(HeaderType headerType, String extension) throws Exception {
     File tmp = new File("target/test/complete/" + headerType + "/test_remove");
     FileUtils.copyFilesToFolder(new File("src/test/resources/complete/" + headerType), tmp);
 
@@ -212,7 +205,7 @@ class CompleteMojoTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void test_check_failed(String name) throws Exception {
+  void test_check_failed(HeaderType headerType, String extension) throws Exception {
     File tmp = new File("target/test/complete/" + headerType + "/test_check_failed");
     FileUtils.copyFilesToFolder(new File("src/test/resources/complete/" + headerType), tmp);
 
@@ -234,7 +227,7 @@ class CompleteMojoTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void test_check_success(String name) throws Exception {
+  void test_check_success(HeaderType headerType, String extension) throws Exception {
     File tmp = new File("target/test/complete/" + headerType + "/test_check_success");
     FileUtils.copyFilesToFolder(new File("src/test/resources/complete/" + headerType), tmp);
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
@@ -33,7 +33,7 @@ class DefaultHeaderDefinitionTest {
     Header header = new Header(new UrlHeaderSource(getClass().getResource("/test-header1.txt"), "UTF-8"), null);
     for (HeaderDefinition definition : HeaderType.defaultDefinitions().values()) {
       final String content = FileUtils.read(new File(format("src/test/resources/styles/%s.txt", definition.getType())), System.getProperty("file.encoding"));
-      Assertions.assertEquals("Bad header for type: " + definition.getType(), content, header.buildForDefinition(definition, !containsWindowsLineEnding(content)));
+      Assertions.assertEquals(content, header.buildForDefinition(definition, !containsWindowsLineEnding(content)), "Bad header for type: " + definition.getType());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <jdk.version>1.8</jdk.version>
     <source.encoding>UTF-8</source.encoding>
     <mycila.github.name>license-maven-plugin</mycila.github.name>
+    <jacoco.minimum.coverage>1.00</jacoco.minimum.coverage>
     <junit.version>5.8.2</junit.version>
   </properties>
 
@@ -128,6 +129,18 @@
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>3.2.2</version>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <reportSets>
+         <reportSet>
+           <reports>
+             <!-- select non-aggregate reports -->
+             <report>report</report>
+           </reports>
+         </reportSet>
+       </reportSets>
+     </plugin>
     </plugins>
   </reporting>
 
@@ -261,6 +274,45 @@ limitations under the License.
             <exclude>docs/**</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.7</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>${jacoco.minimum.coverage}</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.2.2</version>
           <dependencies>


### PR DESCRIPTION
This resolves shortcoming in junit 5 migration.  I had initially wrote that code months ago and coming back to it only ran on command line.  Outside of missing import changes in a few spots at that time, it appeared my work was done.  However, the jump to junit 5 resulted in command line tests no longer running which then highlighted this was not complete on a small number of tests.  To ensure this type of thing never happens again, I've added jacoco to the mix.  Each pom has jacoco coverage number set.  The top one which is just pom is set to 100% for clarity reasons.  The other three are set to their appropriate current code coverage (git module 81%, svn module has no tests, and main plugin at 77%).  The svn module didn't actually need the setting as jacoco is skipped when no tests but presume we want to provision tests there at some point.  We may want to go further here and add coveralls to show the coverage overall for the repo itself.

note: jacoco reports will get added, these are not shown from main site but that site needs some retooling to fluido and few other things so it looks modern rather than legacy apache LAF. [update: noticed this behavior locally to not show jacoco from the site directly was due to attach of descriptor only rather than full site run that is going to happen after merge with github action.  I have updated to fluido locally though and it looks improved and also noting that main site on readme points to the old gh pages unless there is some other magic].