### PR TITLE
Accept skipLinePattern as property name

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
@@ -190,6 +190,8 @@ public final class HeaderDefinition {
       afterEachLine = value;
     } else if ("skipLine".equalsIgnoreCase(property)) {
       skipLinePattern = compile(value);
+    } else if ("skipLinePattern".equals(property)) {
+      skipLinePattern = compile(value);
     } else if ("padLines".equalsIgnoreCase(property)) {
       padLines = Boolean.parseBoolean(value);
     } else if ("firstLineDetectionPattern".equalsIgnoreCase(property)) {


### PR DESCRIPTION
This should be intuitive. I configure `skipLinePattern` and it doesn't work. Later I found it is `skipLine` which is weird.