### PR TITLE
fix: Configure the project for the `ProjectBuildingRequest` being used.

### DIFF
--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
@@ -103,7 +103,7 @@ class MavenProjectLicensesIT {
     final String description = "A project with enforcement enabled but nothing in scope should find zero dependencies";
     syncTarget("null");
 
-    Assertions.assertTrue(hasLogLine(LicenseMessage.INFO_DEPS_DISCOVERED + ": 1"), description);
+    Assertions.assertTrue(hasLogLine(LicenseMessage.INFO_DEPS_DISCOVERED + ": 0"), description);
   }
 
   @Test


### PR DESCRIPTION
The `ProjectBuildingRequest` requires a project to be configured. This project is not available by default. The `ProjectBuildingRequest` is mutable, so I did not use the exiting class variable. Instead, I suggest not storing the request but create one as needed. For that purpose, the Maven session is now kept around.

When requiring a request with a project, the existing copy-constructor is new used and a project is configured as needed.

This change also fixes the tests (expecting 0 instead of 1 dependencies). This change has little effect though, as the `MavenProjectLicensesIT` does not actually run.

This fixes #377.
