### PR TITLE
refactor: Use Maven Integration Test framework to run some integration tests.

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -122,6 +122,48 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>com.soebes.itf.jupiter.extension</groupId>
+        <artifactId>itf-maven-plugin</artifactId>
+        <version>0.12.0</version>
+        <executions>
+          <execution>
+            <id>installing</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>install</goal>
+              <goal>resources-its</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <maven.version>${maven.version}</maven.version>
+            <maven.home>${maven.home}</maven.home>
+          </systemProperties>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled=true
+              junit.jupiter.execution.parallel.mode.default=concurrent
+              junit.jupiter.execution.parallel.mode.classes.default=same_thread
+              junit.jupiter.execution.parallel.config.strategy=fixed
+              junit.jupiter.execution.parallel.config.fixed.parallelism=6
+            </configurationParameters>
+          </properties>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -241,6 +283,20 @@
           </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>com.soebes.itf.jupiter.extension</groupId>
+      <artifactId>itf-assertj</artifactId>
+      <version>0.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.soebes.itf.jupiter.extension</groupId>
+      <artifactId>itf-jupiter-extension</artifactId>
+      <version>0.12.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/approve/pom.xml
+++ b/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/approve/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${env.LICENSE_PLUGIN_VERSION}</version>
+        <version>@project.version@</version>
         <executions>
           <execution>
             <goals>

--- a/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/deny/pom.xml
+++ b/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/deny/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${env.LICENSE_PLUGIN_VERSION}</version>
+        <version>@project.version@</version>
         <executions>
           <execution>
             <goals>

--- a/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/no_dependencies/pom.xml
+++ b/license-maven-plugin/src/test/resources-its/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT/no_dependencies/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${env.LICENSE_PLUGIN_VERSION}</version>
+        <version>@project.version@</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>3.0.0-M8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.4.0</version>
           <dependencies>


### PR DESCRIPTION
For a full reasoning of this PR please have a look at the commit message of ccfafe7. This PR is based on PR #473 and contains ac9a205 from that PR.

In short: The changes makes `MavenProjectLIncensesIT` run proper and delegates all the resource copying to the Maven Integration test framework.

- fix: Configure the project for the `ProjectBuildingRequest` being used.
- refactor: Use Maven Integration Test framework to run some integration tests.
