### PR TITLE
Add fix guidance to default `check` error message

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -44,8 +44,8 @@ import java.util.stream.Collectors;
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {
 
-  @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header")
-  public String errorMessage = "Some files do not have the expected license header";
+  @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header. Run license:format to update them.")
+  public String errorMessage = "Some files do not have the expected license header. Run license:format to update them.";
 
   public final Collection<File> missingHeaders = new ConcurrentLinkedQueue<>();
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
@@ -41,7 +41,7 @@ class AdditionalHeaderMojoTest {
       check.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     check.defaultHeaderDefinitions = new String[]{"/check/def/additionalHeaderDefinitions.xml"};
@@ -60,7 +60,7 @@ class AdditionalHeaderMojoTest {
       check.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     HeaderStyle style = new HeaderStyle();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
@@ -62,7 +62,7 @@ class AggregateMojoTest {
       check.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -53,7 +53,7 @@ class CheckTest {
       check.strictCheck = true;
       check.execute();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     // prepare to reformat the file

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
@@ -222,7 +222,7 @@ class CompleteMojoTest {
       plugin.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
@@ -49,7 +49,7 @@ class MappingMojoTest {
       e.printStackTrace(System.out);
       //assertFalse(logger.getContent().contains("header style: javadoc_style"));
       //assertTrue(logger.getContent().contains("header style: text"));
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     logger.clear();
@@ -63,7 +63,7 @@ class MappingMojoTest {
     } catch (MojoExecutionException e) {
       Assertions.assertTrue(logger.getContent().contains("header style: javadoc_style"));
       Assertions.assertFalse(logger.getContent().contains("header style: text"));
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 
@@ -87,7 +87,7 @@ class MappingMojoTest {
     } catch (MojoExecutionException e) {
       e.printStackTrace(System.out);
       Assertions.assertTrue(logger.getContent().contains("test.apt.vm [header style: sharpstar_style]"));
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     check.setLog(new SystemStreamLog());
@@ -155,7 +155,7 @@ class MappingMojoTest {
     } catch (MojoExecutionException e) {
       e.printStackTrace(System.out);
       Assertions.assertTrue(mappedLogger.getContent().contains("extensionless-file [header style: script_style]"));
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
   }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
@@ -50,7 +50,7 @@ class StrictTest {
     try {
       check.execute();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
     System.out.println(check.missingHeaders);
     Assertions.assertEquals(4, check.missingHeaders.size());

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
@@ -106,7 +106,7 @@ class UpdateMojoTest {
       check.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
       Assertions.assertEquals(1, check.missingHeaders.size());
     }
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
@@ -38,7 +38,7 @@ class UseDefaultExcludesMojoTest {
       check.strictCheck = true;
       check.execute();
     } catch (Exception e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 
@@ -64,7 +64,7 @@ class UseDefaultExcludesMojoTest {
       check.strictCheck = true;
       check.execute();
     } catch (Exception e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
@@ -61,7 +61,7 @@ class UseDefaultMappingMojoTest {
       Assertions.assertTrue(logger.getContent().contains("header style: text"));
       String absoluteDockerfileName = new File("src/test/resources/check/Dockerfile").getCanonicalPath().replace('\\', '/');
       Assertions.assertTrue(logger.getContent().contains("Header OK in: " + absoluteDockerfileName));
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
   }
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
@@ -43,7 +43,7 @@ class ValidHeaderMojoTest {
       check.execute();
       Assertions.fail();
     } catch (MojoExecutionException e) {
-      Assertions.assertEquals("Some files do not have the expected license header", e.getMessage());
+      Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
     check.legacyConfigValidHeaders = new String[]{"src/test/resources/check/header2.txt"};


### PR DESCRIPTION
Closes #531.

This changes the `check` mojo default error message from:

```
Some files do not have the expected license header
```

to:

```
Some files do not have the expected license header. Run license:format to update them.
```

Two questions:
- [ ] Should I manually update the error message in the files under `docs/reports/4.3-SNAPSHOT`?
- [ ] If I execute `mvn clean verify`, some non-Java files in scope for git are modified. Am I supposed to push these changes as well?