### PR TITLE
add license-maven-plugin-fs

### DIFF
--- a/license-maven-plugin-fs/README.md
+++ b/license-maven-plugin-fs/README.md
@@ -1,0 +1,70 @@
+license-maven-plugin-fs
+========================
+
+It is quite common that legal departments require updating of copyright years in header sections whenever the given source file changes. `license-maven-plugin-fs` aims at making it easier not only to enforce this requirement but also to fix found inconsistencies.
+
+What is license-maven-plugin-fs?
+---------------------------------
+
+* `license-maven-plugin-fs` can optionally be used with `license-maven-plugin` to bring in properties (esp. the year of the last change) from the filesystem.
+* The properties added by `license-maven-plugin-fs` can be used in file header templates used by `license-maven-plugin`
+
+Which properties is license-maven-plugin-git adding?
+----------------------------------------------------
+
+* `license.fs.copyrightLastYear` - the year of the last change of the present file as seen in git history
+* `license.fs.copyrightYears` - the combination of `project.inceptionYear` and `license.fs.copyrightLastYear` delimited by a dash (`-`), or just `project.inceptionYear` if `project.inceptionYear` is equal to `license.fs.copyrightLastYear`
+
+How to use license-maven-plugin-fs
+-----------------------------------
+
+Just add `license-maven-plugin-fs` as a dependency to `license-maven-plugin` in your pom.xml file:
+
+``` xml
+...
+<properties>
+  <!-- This quite certainly out of date at the time when you are reading this -->
+  <license-maven-plugin.version>4.2.rc3</license-maven-plugin.version>
+</properties>
+...
+<build>
+  </plugins>
+     ...
+
+    <plugin>
+      <groupId>com.mycila</groupId>
+      <artifactId>license-maven-plugin</artifactId>
+      <version>${license-maven-plugin.version}</version>
+      <configuration>
+        <header>my-header-folder/my-header-template.txt</header>
+       ...
+      </configuration>
+      <dependencies>
+        <dependency>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin-fs</artifactId>
+          <!-- make sure you use the same version as license-maven-plugin -->
+          <version>${license-maven-plugin.version}</version>
+        </dependency>
+      </dependencies>
+      <executions>
+        ...
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+With this configuration in place, you can use `license.fs.copyrightLastYear` and `license.fs.copyrightYears` in your header template. E.g. the beginning of the file `my-header-folder/my-header-template.txt` from the above example might look like this:
+
+``` bash
+Copyright ${license.fs.copyrightYears} My Company, Inc.
+...
+```
+
+For combination a project with `inceptionYear` 1999 and file with last change in 2006, this example template would be resolved by `license-maven-plugin` to something like this:
+
+```
+Copyright 1999-2006 My Company, Inc.
+...
+```

--- a/license-maven-plugin-fs/README.md
+++ b/license-maven-plugin-fs/README.md
@@ -9,10 +9,10 @@ What is license-maven-plugin-fs?
 * `license-maven-plugin-fs` can optionally be used with `license-maven-plugin` to bring in properties (esp. the year of the last change) from the filesystem.
 * The properties added by `license-maven-plugin-fs` can be used in file header templates used by `license-maven-plugin`
 
-Which properties is license-maven-plugin-git adding?
+Which properties is license-maven-plugin-fs adding?
 ----------------------------------------------------
 
-* `license.fs.copyrightLastYear` - the year of the last change of the present file as seen in git history
+* `license.fs.copyrightLastYear` - the year of the last change of the present file, seen as last modification time in the filesystem.
 * `license.fs.copyrightYears` - the combination of `project.inceptionYear` and `license.fs.copyrightLastYear` delimited by a dash (`-`), or just `project.inceptionYear` if `project.inceptionYear` is equal to `license.fs.copyrightLastYear`
 
 How to use license-maven-plugin-fs

--- a/license-maven-plugin-fs/pom.xml
+++ b/license-maven-plugin-fs/pom.xml
@@ -1,0 +1,65 @@
+<!--
+
+    Copyright (C) 2008-2023 Mycila (mathieu.carbou@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License").
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.mycila</groupId>
+    <artifactId>license-maven-plugin-parent</artifactId>
+    <version>4.3-SNAPSHOT</version>
+  </parent>
+  <artifactId>license-maven-plugin-fs</artifactId>
+  <packaging>jar</packaging>
+
+  <name>license-maven-plugin-fs</name>
+  <description>An optional module for license-maven-plugin adding filesystem related functionality</description>
+
+  <reporting>
+    <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
+  </reporting>
+
+  <distributionManagement>
+    <site>
+      <id>report</id>
+      <url>https://mycila.carbou.me/license-maven-plugin/reports/${project.version}/${project.artifactId}</url>
+    </site>
+  </distributionManagement>
+
+  <properties>
+    <jacoco.minimum.coverage>0.50</jacoco.minimum.coverage>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.mycila</groupId>
+      <artifactId>license-maven-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
+++ b/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
@@ -41,11 +41,10 @@ public class CopyrightRangeProvider implements PropertiesProvider {
   public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
 
   /**
-   * Returns an unmodifiable map containing the following entries, whose values are set based on inspecting git history.
+   * Returns an unmodifiable map containing the following entries, whose values are set based on inspecting the filesystem.
    *
    * <ul>
-   * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
-   * modified the supplied {@code document}.</li>
+   * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the file's last modification timestamp .</li>
    * <li>{@value #COPYRIGHT_YEARS_KEY} key stores the range from {@value #INCEPTION_YEAR_KEY} value to
    * {@value #COPYRIGHT_LAST_YEAR_KEY} value. If both values a equal, only the {@value #INCEPTION_YEAR_KEY} value is
    * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000-2010"}.</li>

--- a/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
+++ b/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2008-2023 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.fs;
+
+import com.mycila.maven.plugin.license.AbstractLicenseMojo;
+import com.mycila.maven.plugin.license.PropertiesProvider;
+import com.mycila.maven.plugin.license.document.Document;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.time.ZoneOffset.UTC;
+
+/**
+ * An implementation of {@link PropertiesProvider} that adds {@value #COPYRIGHT_LAST_YEAR_KEY} and
+ * {@value #COPYRIGHT_YEARS_KEY} values - see {@link #adjustProperties(AbstractLicenseMojo, Map,
+ * Document)}.
+ *
+ * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
+ */
+public class CopyrightRangeProvider implements PropertiesProvider {
+
+  public static final String COPYRIGHT_LAST_YEAR_KEY = "license.fs.copyrightLastYear";
+  public static final String COPYRIGHT_YEARS_KEY = "license.fs.copyrightYears";
+  public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
+
+  /**
+   * Returns an unmodifiable map containing the following entries, whose values are set based on inspecting git history.
+   *
+   * <ul>
+   * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
+   * modified the supplied {@code document}.</li>
+   * <li>{@value #COPYRIGHT_YEARS_KEY} key stores the range from {@value #INCEPTION_YEAR_KEY} value to
+   * {@value #COPYRIGHT_LAST_YEAR_KEY} value. If both values a equal, only the {@value #INCEPTION_YEAR_KEY} value is
+   * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000-2010"}.</li>
+   * </ul>
+   * The {@value #INCEPTION_YEAR_KEY} value is read from the supplied properties and it must available. Otherwise a
+   * {@link RuntimeException} is thrown.
+   */
+  @Override
+  public Map<String, String> adjustProperties(AbstractLicenseMojo mojo,
+                                              Map<String, String> properties, Document document) {
+    String inceptionYear = properties.get(INCEPTION_YEAR_KEY);
+    if (inceptionYear == null) {
+      throw new RuntimeException("'" + INCEPTION_YEAR_KEY + "' must have a value for file "
+          + document.getFile().getAbsolutePath());
+    }
+    final int inceptionYearInt;
+    try {
+      inceptionYearInt = Integer.parseInt(inceptionYear);
+    } catch (NumberFormatException e1) {
+      throw new RuntimeException(
+          "'" + INCEPTION_YEAR_KEY + "' must be an integer ; found = " + inceptionYear + " file: "
+              + document.getFile().getAbsolutePath());
+    }
+    try {
+      Map<String, String> result = new HashMap<>(4);
+
+      int copyrightEnd = getYearOfLastChange(document.getFile());
+      result.put(COPYRIGHT_LAST_YEAR_KEY, Integer.toString(copyrightEnd));
+      final String copyrightYears;
+      if (inceptionYearInt >= copyrightEnd) {
+        copyrightYears = inceptionYear;
+      } else {
+        copyrightYears = inceptionYear + "-" + copyrightEnd;
+      }
+      result.put(COPYRIGHT_YEARS_KEY, copyrightYears);
+
+      return Collections.unmodifiableMap(result);
+    } catch (Throwable e) {
+      throw new RuntimeException(
+          "CopyrightRangeProvider error on file: " + document.getFile().getAbsolutePath() + ": "
+              + e.getMessage(), e);
+    }
+  }
+
+  private static int getYearOfLastChange(File file) {
+    return Instant.ofEpochMilli(file.lastModified()).atOffset(UTC).getYear();
+  }
+
+}

--- a/license-maven-plugin-fs/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
+++ b/license-maven-plugin-fs/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
@@ -1,0 +1,1 @@
+com.mycila.maven.plugin.license.fs.CopyrightRangeProvider

--- a/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
@@ -53,7 +53,7 @@ class CopyrightRangeProviderTest {
       assertRange(provider, "dir1/file1.txt", "2023", "1999-2023");
       assertRange(provider, "dir1/file2.txt", "1999", "1999");
 
-      /* The last change of file3.txt in git history is in 1999
+      /* The last change of file3.txt is in 1999
        * but the inception year is 2000
        * and we do not want the range to go back (2000-1999)
        * so in this case we expect just 2000

--- a/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2008-2023 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.fs;
+
+import com.mycila.maven.plugin.license.LicenseCheckMojo;
+import com.mycila.maven.plugin.license.document.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+class CopyrightRangeProviderTest {
+  private static Path fsRepoRoot;
+
+  @TempDir
+  static File tempFolder;
+
+  @Test
+  void copyrightRange() {
+    CopyrightRangeProvider provider = new CopyrightRangeProvider();
+
+    Map<String, String> props = new HashMap<>();
+    final LicenseCheckMojo mojo = new LicenseCheckMojo();
+    mojo.defaultBasedir = fsRepoRoot.toFile();
+    try {
+      provider.init(mojo, props);
+
+      assertRange(provider, "dir1/file1.txt", "2023", "1999-2023");
+      assertRange(provider, "dir1/file2.txt", "1999", "1999");
+
+      /* The last change of file3.txt in git history is in 1999
+       * but the inception year is 2000
+       * and we do not want the range to go back (2000-1999)
+       * so in this case we expect just 2000
+       * However for existence years always report the actual year regardless
+       * of the inception year so expect 1999 for that */
+      assertRange(provider, "dir2/file3.txt", "2000", "1999", "2000");
+
+    } finally {
+      provider.close();
+    }
+  }
+
+  private void assertRange(CopyrightRangeProvider provider, String path, String copyrightEnd, String copyrightRange) {
+    assertRange(provider, path, "1999", copyrightEnd, copyrightRange);
+  }
+
+  private void assertRange(CopyrightRangeProvider provider, String path, String inceptionYear, String copyrightEnd, String copyrightRange) {
+    Map<String, String> props = new HashMap<>();
+    props.put(CopyrightRangeProvider.INCEPTION_YEAR_KEY, inceptionYear);
+
+    Document document = newDocument(path);
+    Map<String, String> actual = provider.adjustProperties(new LicenseCheckMojo(), props, document);
+
+    HashMap<String, String> expected = new HashMap<String, String>();
+    expected.put(CopyrightRangeProvider.COPYRIGHT_LAST_YEAR_KEY, copyrightEnd);
+    expected.put(CopyrightRangeProvider.COPYRIGHT_YEARS_KEY, copyrightRange);
+    Assertions.assertEquals(expected, actual, "for file '" + path + "': ");
+  }
+
+  private static Document newDocument(String relativePath) {
+    Path path = Paths.get(fsRepoRoot + File.separator
+        + relativePath.replace('/', File.separatorChar));
+    return new Document(path.toFile(), null, "utf-8", new String[0], null);
+  }
+
+  @BeforeAll
+  static void beforeClass() throws IOException {
+    fsRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "fs-test-repo");
+
+    Files.createDirectories(fsRepoRoot.resolve("dir1"));
+    Files.createFile(fsRepoRoot.resolve("dir1/file1.txt"));
+    Files.createFile(fsRepoRoot.resolve("dir1/file2.txt"));
+
+    Files.createDirectory(fsRepoRoot.resolve("dir2"));
+    Files.createFile(fsRepoRoot.resolve("dir2/file3.txt"));
+
+    Files.setLastModifiedTime(fsRepoRoot.resolve("dir1/file1.txt"), FileTime.from(Instant.parse("2023-06-10T13:13:13.00Z")));
+    Files.setLastModifiedTime(fsRepoRoot.resolve("dir1/file2.txt"), FileTime.from(Instant.parse("1999-06-10T13:13:13.00Z")));
+    Files.setLastModifiedTime(fsRepoRoot.resolve("dir2/file3.txt"), FileTime.from(Instant.parse("1999-06-10T13:13:13.00Z")));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <module>license-maven-plugin</module>
     <module>license-maven-plugin-git</module>
     <module>license-maven-plugin-svn</module>
+    <module>license-maven-plugin-fs</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
This plugin implements a `PropertiesProvider` bringing properties
`license.fs.copyrightLastYear` and `license.fs.copyrightYears`, very similar to the git plugin does.

Those properties are filled from filesystem last modification timestamp.

This is useful for use with version control systems that preserve filesystem time from commit time, like RTC does.
