### PR TITLE
[author] Extract out legacy usage of author annotations in favor of adding to pom

### DIFF
--- a/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
+++ b/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
@@ -31,8 +31,6 @@ import static java.time.ZoneOffset.UTC;
  * An implementation of {@link PropertiesProvider} that adds {@value #COPYRIGHT_LAST_YEAR_KEY} and
  * {@value #COPYRIGHT_YEARS_KEY} values - see {@link #adjustProperties(AbstractLicenseMojo, Map,
  * Document)}.
- *
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
 public class CopyrightRangeProvider implements PropertiesProvider {
 

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
@@ -29,8 +29,6 @@ import java.util.Map;
  * An implementation of {@link PropertiesProvider} that adds {@value
  * #COPYRIGHT_CREATION_AUTHOR_NAME_KEY} and {@value #COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY} values -
  * see {@link #adjustProperties(AbstractLicenseMojo, Map, Document)}.
- *
- * @author masakimu
  */
 public class CopyrightAuthorProvider implements PropertiesProvider {
 

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
@@ -29,8 +29,6 @@ import java.util.Map;
  * An implementation of {@link PropertiesProvider} that adds {@value #COPYRIGHT_LAST_YEAR_KEY} and
  * {@value #COPYRIGHT_YEARS_KEY} values - see {@link #adjustProperties(AbstractLicenseMojo, Map,
  * Document)}.
- *
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
 public class CopyrightRangeProvider implements PropertiesProvider {
 

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -54,8 +54,6 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A jGit library wrapper to query the date of the last commit.
- *
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
 public class GitLookup implements Closeable {
 

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
@@ -20,8 +20,6 @@ import java.io.File;
 /**
  * A utility to transform native {@link File} paths to the form expected by jGit - i.e. relative to git working tree
  * root directory and delimited by {@code '/'}.
- *
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
  */
 public class GitPathResolver {
 

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
@@ -30,9 +30,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
- */
 class CopyrightAuthorProviderTest {
 
   private static Path gitRepoRoot;

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
@@ -30,9 +30,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
- */
 class CopyrightRangeProviderTest {
 
   private static Path gitRepoRoot;

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
@@ -38,9 +38,6 @@ import java.util.TimeZone;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-/**
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
- */
 class GitLookupTest {
 
   private static Path gitRepoRoot;

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitPathResolverTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitPathResolverTest.java
@@ -18,9 +18,6 @@ package com.mycila.maven.plugin.license.git;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
- */
 class GitPathResolverTest {
 
   @Test

--- a/license-maven-plugin-svn/src/main/java/com/mycila/maven/plugin/license/svn/SVNPropertiesProvider.java
+++ b/license-maven-plugin-svn/src/main/java/com/mycila/maven/plugin/license/svn/SVNPropertiesProvider.java
@@ -40,8 +40,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * An implementation of {@link PropertiesProvider} that uses SVN to retrieve
  * year information of last modification of files.
- *
- * @author Matthieu Brouillard
  */
 public class SVNPropertiesProvider implements PropertiesProvider {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Credentials.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Credentials.java
@@ -17,8 +17,6 @@ package com.mycila.maven.plugin.license;
 
 /**
  * Simple wrapper class to transport login/password information.
- *
- * @author Matthieu Brouillard
  */
 public class Credentials {
   private final String login;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -15,10 +15,6 @@
  */
 package com.mycila.maven.plugin.license;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- * 2013-08-01
- */
 public final class Default {
 
   private Default() {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
@@ -18,9 +18,6 @@ package com.mycila.maven.plugin.license;
 import com.mycila.maven.plugin.license.header.HeaderDefinition;
 import org.apache.maven.plugins.annotations.Parameter;
 
-/**
- * @author Mathieu Carbou
- */
 public class HeaderStyle {
 
   /**

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -38,8 +38,6 @@ import java.util.stream.Collectors;
 
 /**
  * Check if the source files of the project have a valid license header
- *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
@@ -25,8 +25,6 @@ import java.io.File;
 
 /**
  * Reformat files with a missing header to add it
- *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 @Mojo(name = "format", threadSafe = true)
 public final class LicenseFormatMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
@@ -25,8 +25,6 @@ import java.io.File;
 
 /**
  * Remove the specified header from source files
- *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 @Mojo(name = "remove", threadSafe = true)
 public final class LicenseRemoveMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com) 2013-08-27
  */
 public interface PropertiesProvider extends Closeable {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Report.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Report.java
@@ -36,9 +36,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-/**
- * @author Mathieu Carbou
- */
 public class Report {
 
   enum Action {CHECK, FORMAT, REMOVE}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
@@ -19,7 +19,6 @@ package com.mycila.maven.plugin.license.dependencies;
  * Base class for all policy enforcer implementations.
  *
  * @param <T>
- * @author Royce Remer
  */
 public abstract class AbstractLicensePolicyEnforcer<T> implements LicensePolicyEnforcer<T> {
   private final LicensePolicy policy;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
@@ -31,8 +31,6 @@ import java.util.stream.Collectors;
  * 1) defaultPolicy: unless overridden via setDefaultPolicy, this will DENY all artifacts.
  * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule.APPROVE}
  * 3) DENY policies: any policy in the Set which have {@link LIcensePolicy.Rule.DENY}
- *
- * @author Royce Remer
  */
 @SuppressWarnings("rawtypes")
 public class AggregateLicensePolicyEnforcer {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 
 /**
  * Make policy decisions on a {@link Artifact} based on an {@link ArtifactFilter}.
- *
- * @author Royce Remer
  */
 public class ArtifactLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<Artifact> {
   private ArtifactFilter filter;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
@@ -17,8 +17,6 @@ package com.mycila.maven.plugin.license.dependencies;
 
 /**
  * A default deny ArtifactLicensePolicyEnforcer.
- *
- * @author Royce Remer
  */
 public class DefaultLicensePolicyEnforcer extends ArtifactLicensePolicyEnforcer {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
@@ -24,8 +24,6 @@ import java.util.Set;
 /**
  * To be implemented by different project/build-framework scanners presenting
  * licenses of dependencies.
- *
- * @author Royce Remer
  */
 public interface LicenseMap {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
@@ -17,8 +17,6 @@ package com.mycila.maven.plugin.license.dependencies;
 
 /**
  * Expose message text to config and tests.
- *
- * @author Royce Remer
  */
 public interface LicenseMessage {
   String WARN_POLICY_DENIED = "Some licenses were denied by policy:";

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
@@ -19,8 +19,6 @@ import org.apache.maven.model.License;
 
 /**
  * Make policy decisions on a {@link License} based on the license name.
- *
- * @author Royce Remer
  */
 public class LicenseNameLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 /**
  * A policy decision based on some matcher/value and type. Different policy
  * enforcers should take this class as a constructor argument.
- *
- * @author Royce Remer
  */
 public class LicensePolicy {
   public enum Type {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
@@ -17,8 +17,6 @@ package com.mycila.maven.plugin.license.dependencies;
 
 /**
  * Methods exposed by enforcer implementations using {@link LicensePolicy}.
- *
- * @author Royce Remer
  */
 public interface LicensePolicyEnforcer<T> {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
@@ -19,8 +19,6 @@ import org.apache.maven.model.License;
 
 /**
  * Make policy decisions on a {@link License} based on the license URL.
- *
- * @author Royce Remer
  */
 public class LicenseURLLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
@@ -44,8 +44,6 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Helper class for building Artifact/License mappings from a maven project
  * (multi module or single).
- *
- * @author Royce Remer
  */
 public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentPropertiesLoader.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentPropertiesLoader.java
@@ -17,10 +17,6 @@ package com.mycila.maven.plugin.license.document;
 
 import java.util.Map;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- * 2013-08-27
- */
 public interface DocumentPropertiesLoader {
 
   Map<String, String> load(Document d);

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/PropertyPlaceholderResolver.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/PropertyPlaceholderResolver.java
@@ -30,8 +30,6 @@ import java.util.function.Function;
  * user-supplied values. <p> Values for substitution can be supplied using a {@link Properties} instance or
  * using a {@link Function}.
  *
- * @author Juergen Hoeller
- * @author Rob Harrop
  * @since 3.0
  */
 class PropertyPlaceholderResolver {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinition.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinition.java
@@ -57,8 +57,6 @@ import java.util.Map;
  *   &lt;/xs:complexType&gt;
  *  &lt;/xs:schema&gt;
  * </pre>
- *
- * @author Cedric Pronzato
  */
 public final class AdditionalHeaderDefinition {
   private final Map<String, HeaderDefinition> definitions = new HashMap<>();

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
@@ -32,8 +32,6 @@ import static com.mycila.maven.plugin.license.util.FileUtils.remove;
 /**
  * The <code>Header</code> class wraps the license template file, the one which have to be outputted inside the other
  * files.
- *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 public final class Header {
   private final HeaderSource location;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
@@ -21,8 +21,6 @@ import java.util.regex.Pattern;
  * The <code>HeaderDefinition</code> class defines what is needed to output a header text into the of the given file
  * type and what is needed to match the first line as well as the last line of a previous header of the given file
  * type. Optionally you can define the lines you want to skip before outputting the header.
- *
- * @author Cedric Pronzato
  */
 public final class HeaderDefinition {
   private final String type;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
@@ -26,7 +26,6 @@ import com.mycila.maven.plugin.license.util.StringUtils;
  * within a section of the file which match the given <code>HeaderDefinition</code> associated to this
  * <code>HeaderParser</code>.
  *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  * @see com.mycila.maven.plugin.license.header.HeaderDefinition
  */
 public final class HeaderParser {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
@@ -27,8 +27,6 @@ import static com.mycila.maven.plugin.license.Multi.DEFAULT_SEPARATOR;
 
 /**
  * Provides an access to the license template text.
- *
- * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
 public abstract class HeaderSource {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
@@ -22,8 +22,6 @@ import java.util.Map;
 /**
  * Defines the default header definitions available out of the box within this plugin.
  *
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- * @author Cedric Pronzato
  * @see com.mycila.maven.plugin.license.header.HeaderDefinition
  */
 public enum HeaderType {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileContent.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileContent.java
@@ -20,9 +20,6 @@ import java.io.IOException;
 
 import static com.mycila.maven.plugin.license.util.FileUtils.read;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 public final class FileContent {
   private final File file;
   private final StringBuilder fileContent;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
@@ -15,9 +15,6 @@
  */
 package com.mycila.maven.plugin.license.util;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 public final class StringUtils {
 
   private StringUtils() {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/CustomClassLoader.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/CustomClassLoader.java
@@ -20,9 +20,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 final class CustomClassLoader extends URLClassLoader {
   CustomClassLoader() {
     super(new URL[0], null);

--- a/license-maven-plugin/src/test/java/MyPropertiesProvider.java
+++ b/license-maven-plugin/src/test/java/MyPropertiesProvider.java
@@ -5,9 +5,6 @@ import com.mycila.maven.plugin.license.document.Document;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com) 2013-08-27
- */
 public final class MyPropertiesProvider implements PropertiesProvider {
 
   @Override

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AbstractLicenseMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AbstractLicenseMojoTest.java
@@ -6,9 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-/**
- * @author Matthieu Brouillard
- */
 class AbstractLicenseMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
@@ -24,9 +24,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.Collections;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class AdditionalHeaderMojoTest {
   @Test
   void test_additionalHeaderDefinitions() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
@@ -24,9 +24,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class AggregateMojoTest {
   @Test
   void test_modules_ignored() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -23,9 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class CheckTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
@@ -71,9 +71,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class CompleteMojoTest {
 
   private static Stream<Object[]> parameters() {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class ExcludesMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class FailIfMissingMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
@@ -21,9 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class HeaderMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class IncludesMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
@@ -26,9 +26,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class MappingMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MockedLog.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MockedLog.java
@@ -21,9 +21,6 @@ import org.codehaus.plexus.logging.Logger;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 final class MockedLog extends AbstractLogger {
 
   private final StringWriter sw = new StringWriter();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class QuietMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
@@ -25,9 +25,6 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.List;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 final class RemoveMojoTest {
   public static final String LS = "\n";
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
@@ -33,9 +33,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class ReportTest {
 
   MavenProjectStub mavenProjectStub = new MavenProjectStub();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class StrictTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
@@ -32,9 +32,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class UpdateMojoTest {
 
   public static final String LS = "\n";

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
@@ -21,9 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class UseDefaultExcludesMojoTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
@@ -23,9 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class UseDefaultMappingMojoTest {
   @Test
   void test_not_useDefaultMapping() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
@@ -22,9 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class ValidHeaderMojoTest {
   @Test
   void test_validHeader() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTestBase.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcerTestBase.java
@@ -29,8 +29,6 @@ import java.util.Set;
 
 /**
  * Utility class for test setup methods related to this package.
- *
- * @author Royce Remer
  */
 class ArtifactLicensePolicyEnforcerTestBase {
 
@@ -75,8 +73,6 @@ class ArtifactLicensePolicyEnforcerTestBase {
 
   /**
    * Helper class for tracking test data related to license enforcement.
-   *
-   * @author Royce Remer
    */
   protected class LicenseMapData implements LicenseMap {
     Map<Artifact, LicensePolicyEnforcerResult> expected;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicensesIT.java
@@ -38,9 +38,6 @@ import com.soebes.itf.jupiter.maven.MavenExecutionResult;
  * <p>
  * A good overview of similar woes <a href="https://khmarbaise.github.io/maven-it-extension/itf-documentation/background/background.html">
  *   https://khmarbaise.github.io/maven-it-extension/itf-documentation/background/background.html</a>.
- *
- * @author Royce Remer
- * @author Michael J. Simons
  */
 @MavenJupiterExtension
 public class MavenProjectLicensesIT {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/document/DocumentTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/document/DocumentTest.java
@@ -33,9 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class DocumentTest {
 
   static Header header;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinitionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/AdditionalHeaderDefinitionTest.java
@@ -24,9 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class AdditionalHeaderDefinitionTest {
   @Test
   void test_load_definitions() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/DefaultHeaderDefinitionTest.java
@@ -24,9 +24,6 @@ import java.io.File;
 
 import static java.lang.String.format;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class DefaultHeaderDefinitionTest {
   @Test
   void test_styles() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderDefinitionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderDefinitionTest.java
@@ -18,9 +18,6 @@ package com.mycila.maven.plugin.license.header;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class HeaderDefinitionTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderParserTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderParserTest.java
@@ -27,9 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class HeaderParserTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderTest.java
@@ -24,9 +24,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class HeaderTest {
   @Test
   void test() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderTypeTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderTypeTest.java
@@ -18,9 +18,6 @@ package com.mycila.maven.plugin.license.header;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class HeaderTypeTest {
   @Test
   void test() throws Exception {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/DebugLog.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/DebugLog.java
@@ -3,9 +3,6 @@ package com.mycila.maven.plugin.license.util;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 
-/**
- * @author Mathieu Carbou
- */
 public class DebugLog extends SystemStreamLog implements Log {
   @Override
   public boolean isDebugEnabled() {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/FileContentTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/FileContentTest.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class FileContentTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/FileUtilsTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/FileUtilsTest.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class FileUtilsTest {
 
   @Test

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
@@ -34,9 +34,6 @@ import java.util.UUID;
 
 import static java.util.Arrays.asList;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class SelectionTest {
   private final Log log = new SystemStreamLog();
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/resource/ResourceFinderTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/resource/ResourceFinderTest.java
@@ -26,9 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
 class ResourceFinderTest {
 
   static ResourceFinder finder;

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,87 @@
     <module>license-maven-plugin-fs</module>
   </modules>
 
+  <developers>
+    <developer>
+      <id>mathieucarbou</id>
+      <name>Mathieu Carbou</name>
+      <email>mathieu.carbou@gmail.com</email>
+      <url>https://mathieu.photography/</url>
+      <organization>mathieucarbou</organization>
+      <organizationUrl>https://github.com/mathieucarbou</organizationUrl>
+      <roles>
+        <role>Architect</role>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>jlandis</id>
+      <name>Jeremy Landis</name>
+      <email>jeremylandis@hotmail.com</email>
+      <url>https://www.linkedin.com/in/jeremy-landis-548b2719</url>
+      <organization>hazendaz</organization>
+      <organizationUrl>https://github.com/hazendaz</organizationUrl>
+      <roles>
+        <role>Developer</role>
+      </roles>
+      <timezone>-5</timezone>
+      <properties>
+        <picUrl>https://avatars0.githubusercontent.com/u/975267</picUrl>
+      </properties>
+    </developer>
+  </developers>
+  <contributors>
+    <contributor>
+      <name>Peter Palaga</name>
+      <email>ppalaga@redhat.com</email>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>masakimu</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Matthieu Brouillard</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Royce Remer</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Juergen Hoeller</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Rob Harrop</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Cedric Pronzato</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>Michael J. Simons</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </contributor>
+  </contributors>
+
   <scm>
     <connection>scm:git:https://github.com/mycila/${mycila.github.name}.git</connection>
     <developerConnection>scm:git:git@github.com:mycila/${mycila.github.name}.git</developerConnection>


### PR DESCRIPTION
git stores the history, leaving names ends up in humans blaming sections of code on whom is listed there.  Better to give this in the pom so it further gives higher visibility of those that have contributed and wanted their names listed at one point or another.

This further was causing issues with javadocs as the javadocs on many of these were entirely wrong in that they only had author listed and no context so the javadoc plugin is loud on issues.  Newer maven versions further make warnings far more visible making it important to adjust.

Additionally not all files actually used author this way at all.  So this gets us consistent.  I didn't have the data to fill in everything in general but did what I could.  Some users just had a name so I added it that way.  I think many are already longer term contributors of the repo so the pom.xml could be bridged out further to better show where everyone can be tracked down more easily.