### PR TITLE
[pom] Redirect surefire out put to file as too noisy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.1.0</version>
+          <configuration>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
output is hard to read as it  scrolls off screen buffers due to printing out license data constantly throughout tests.  Instead send test output to logs which makes it easier to read out put and see other issues in our build.