### PR TITLE
[reporting] Do not run reports to docs in windows

### DIFF
--- a/license-maven-plugin-fs/pom.xml
+++ b/license-maven-plugin-fs/pom.xml
@@ -28,10 +28,6 @@
   <name>license-maven-plugin-fs</name>
   <description>An optional module for license-maven-plugin adding filesystem related functionality</description>
 
-  <reporting>
-    <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>report</id>
@@ -62,4 +58,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>report</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <reporting>
+        <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
+      </reporting>
+    </profile>
+  </profiles>
 </project>

--- a/license-maven-plugin-git/pom.xml
+++ b/license-maven-plugin-git/pom.xml
@@ -28,10 +28,6 @@
   <name>license-maven-plugin-git</name>
   <description>An optional module for license-maven-plugin adding git related functionality</description>
 
-  <reporting>
-    <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>report</id>
@@ -67,4 +63,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>report</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <reporting>
+        <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
+      </reporting>
+    </profile>
+  </profiles>
 </project>

--- a/license-maven-plugin-svn/pom.xml
+++ b/license-maven-plugin-svn/pom.xml
@@ -26,10 +26,6 @@
   <artifactId>license-maven-plugin-svn</artifactId>
   <packaging>jar</packaging>
 
-  <reporting>
-    <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>report</id>
@@ -58,4 +54,18 @@
       <version>1.10.11</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>report</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <reporting>
+        <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
+      </reporting>
+    </profile>
+  </profiles>
 </project>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -163,10 +163,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
-  </reporting>
-
   <distributionManagement>
     <site>
       <id>report</id>
@@ -278,10 +274,10 @@
       <version>1.8.0</version>
       <scope>test</scope>
       <exclusions>
-          <exclusion>
-              <groupId>junit</groupId>
-              <artifactId>junit</artifactId>
-          </exclusion>
+        <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -299,5 +295,19 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>report</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <reporting>
+        <outputDirectory>../docs/reports/${project.version}/${project.artifactId}</outputDirectory>
+      </reporting>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,6 @@
   </dependencyManagement>
 
   <reporting>
-    <outputDirectory>docs/reports/${project.version}</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -649,6 +648,17 @@ limitations under the License.
       <properties>
         <maven.compiler.release>8</maven.compiler.release>
       </properties>
+    </profile>
+    <profile>
+      <id>report</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <reporting>
+        <outputDirectory>docs/reports/${project.version}</outputDirectory>
+      </reporting>
     </profile>
   </profiles>
 


### PR DESCRIPTION
do this only on linux where its needed to occur.

Currently usage of this makes it hard for contributors as they are blasted with many changes on every run.  Intent here was to run this on GHA only thus fixing so that it no longer runs on windows.  Maybe there is a more friendly determination of GHA but it is set to use ubuntu there.