### PR TITLE
[javadocs] Fix javadocs clearing all warnings

### DIFF
--- a/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
+++ b/license-maven-plugin-fs/src/main/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProvider.java
@@ -34,8 +34,13 @@ import static java.time.ZoneOffset.UTC;
  */
 public class CopyrightRangeProvider implements PropertiesProvider {
 
+  /** The Constant COPYRIGHT_LAST_YEAR_KEY. */
   public static final String COPYRIGHT_LAST_YEAR_KEY = "license.fs.copyrightLastYear";
+
+  /** The Constant COPYRIGHT_YEARS_KEY. */
   public static final String COPYRIGHT_YEARS_KEY = "license.fs.copyrightYears";
+
+  /** The Constant INCEPTION_YEAR_KEY. */
   public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
 
   /**

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
@@ -32,7 +32,10 @@ import java.util.Map;
  */
 public class CopyrightAuthorProvider implements PropertiesProvider {
 
+  /** The Constant COPYRIGHT_CREATION_AUTHOR_NAME_KEY. */
   public static final String COPYRIGHT_CREATION_AUTHOR_NAME_KEY = "license.git.CreationAuthorName";
+
+  /** The Constant COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY. */
   public static final String COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY = "license.git.CreationAuthorEmail";
 
   private GitLookup gitLookup;

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
@@ -32,10 +32,19 @@ import java.util.Map;
  */
 public class CopyrightRangeProvider implements PropertiesProvider {
 
+  /** The Constant COPYRIGHT_LAST_YEAR_KEY. */
   public static final String COPYRIGHT_LAST_YEAR_KEY = "license.git.copyrightLastYear";
+
+  /** The Constant COPYRIGHT_CREATION_YEAR_KEY. */
   public static final String COPYRIGHT_CREATION_YEAR_KEY = "license.git.copyrightCreationYear";
+
+  /** The Constant COPYRIGHT_EXISTENCE_YEARS_KEY. */
   public static final String COPYRIGHT_EXISTENCE_YEARS_KEY = "license.git.copyrightExistenceYears";
+
+  /** The Constant COPYRIGHT_YEARS_KEY. */
   public static final String COPYRIGHT_YEARS_KEY = "license.git.copyrightYears";
+
+  /** The Constant INCEPTION_YEAR_KEY. */
   public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
 
   private GitLookup gitLookup;

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -57,17 +57,34 @@ import static java.util.Objects.requireNonNull;
  */
 public class GitLookup implements Closeable {
 
+  /** The Constant DEFAULT_ZONE. */
   public static final TimeZone DEFAULT_ZONE = TimeZone.getTimeZone("GMT");
 
+  /** The Constant MAX_COMMITS_LOOKUP_KEY. */
   public static final String MAX_COMMITS_LOOKUP_KEY = "license.git.maxCommitsLookup";
-  // keep for compatibility
-  private static final String COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY = "license.git.copyrightLastYearMaxCommitsLookup";
+
+  /** The Constant COPYRIGHT_LAST_YEAR_SOURCE_KEY. */
   public static final String COPYRIGHT_LAST_YEAR_SOURCE_KEY = "license.git.copyrightLastYearSource";
+
+  /** The Constant COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY. */
   public static final String COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY = "license.git.copyrightLastYearTimeZone";
+
+  /** The Constant COMMITS_TO_IGNORE_KEY. */
   public static final String COMMITS_TO_IGNORE_KEY = "license.git.commitsToIgnore";
 
+  /** The Constant COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY.  Keep for compatibility. */
+  private static final String COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY = "license.git.copyrightLastYearMaxCommitsLookup";
+
+  /**
+   * The Enum DateSource.
+   */
   public enum DateSource {
-    AUTHOR, COMMITER
+
+    /** The author. */
+    AUTHOR,
+
+    /** The commiter. */
+    COMMITER
   }
 
   private final int checkCommitsCount;
@@ -81,6 +98,10 @@ public class GitLookup implements Closeable {
   /**
    * Lazily initializes #gitLookup assuming that all subsequent calls to this method will be related
    * to the same git repository.
+   *
+   * @param file the file
+   * @param props the props
+   * @return the git lookup
    */
   public static GitLookup create(File file, Map<String, String> props) {
     final GitLookup.DateSource dateSource = Optional.ofNullable(props.get(COPYRIGHT_LAST_YEAR_SOURCE_KEY))
@@ -129,7 +150,6 @@ public class GitLookup implements Closeable {
    *                          otherwise must be {@code null}.
    * @param checkCommitsCount the number of historical commits, per file, to check
    * @param commitsToIgnore   the commits to ignore while inspecting the history for {@code anyFile}
-   * @throws IOException
    */
   private GitLookup(File anyFile, DateSource dateSource, TimeZone timeZone, int checkCommitsCount, Set<ObjectId> commitsToIgnore) {
     requireNonNull(anyFile);
@@ -167,8 +187,8 @@ public class GitLookup implements Closeable {
    *
    * @param file for which the year should be retrieved
    * @return year of last modification of the file
-   * @throws IOException     if unable to read the file
    * @throws GitAPIException if unable to process the git history
+   * @throws IOException     if unable to read the file
    */
   int getYearOfLastChange(File file) throws GitAPIException, IOException {
     String repoRelativePath = pathResolver.relativize(file);
@@ -192,12 +212,16 @@ public class GitLookup implements Closeable {
     return commitYear;
   }
 
-  /*
-   * Returns the year of creation for the given {@code file) based on the history of the present git branch. The
+  /**
+   * Returns the year of creation for the given {@code file} based on the history of the present git branch. The
    * year is taken either from the committer date or from the author identity depending on how {@link #dateSource} was
    * initialized.
+   *
+   * @param file the file
+   * @return the year of creation
+   * @throws IOException Signals that an I/O exception has occurred.
    */
-  int getYearOfCreation(File file) throws IOException, GitAPIException {
+  int getYearOfCreation(File file) throws IOException {
     String repoRelativePath = pathResolver.relativize(file);
 
     int commitYear = 0;

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
@@ -23,9 +23,7 @@ import java.io.File;
  */
 public class GitPathResolver {
 
-  /**
-   * The path separator expected by jGit.
-   */
+  /** The path separator expected by jGit. */
   private static final char CANONICAL_PATH_SEPARATOR = '/';
 
   /**
@@ -38,6 +36,11 @@ public class GitPathResolver {
    */
   private final String repositoryRootDir;
 
+  /**
+   * Instantiates a new git path resolver.
+   *
+   * @param repositoryRootDir the repository root dir
+   */
   public GitPathResolver(String repositoryRootDir) {
     this(repositoryRootDir, File.separatorChar);
   }

--- a/license-maven-plugin-svn/src/main/java/com/mycila/maven/plugin/license/svn/SVNPropertiesProvider.java
+++ b/license-maven-plugin-svn/src/main/java/com/mycila/maven/plugin/license/svn/SVNPropertiesProvider.java
@@ -43,13 +43,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class SVNPropertiesProvider implements PropertiesProvider {
 
-
+  /** The Constant SVN_COPYRIGHT_LASTCHANGE_YEAR_KEY. */
   public static final String SVN_COPYRIGHT_LASTCHANGE_YEAR_KEY = "license.svn.lastchange.year";
+
+  /** The Constant SVN_COPYRIGHT_LASTCHANGE_DATE_KEY. */
   public static final String SVN_COPYRIGHT_LASTCHANGE_DATE_KEY = "license.svn.lastchange.date";
+
+  /** The Constant SVN_COPYRIGHT_LASTCHANGE_TIMESTAMP_KEY. */
   public static final String SVN_COPYRIGHT_LASTCHANGE_TIMESTAMP_KEY = "license.svn.lastchange.timestamp";
+
+  /** The Constant SVN_COPYRIGHT_LASTCHANGE_REVISION_KEY. */
   public static final String SVN_COPYRIGHT_LASTCHANGE_REVISION_KEY = "license.svn.lastchange.revision";
+
+  /** The Constant SVN_COPYRIGHT_YEARS_RANGE_KEY. */
   public static final String SVN_COPYRIGHT_YEARS_RANGE_KEY = "license.svn.years.range";
+
+  /** The Constant INCEPTION_YEAR_KEY. */
   public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
+
+  /** The Constant SVN_SERVER_ID_PLUGIN_KEY. */
   public static final String SVN_SERVER_ID_PLUGIN_KEY = "license.svn.serverId";
 
   private Credentials svnCredentials;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -84,6 +84,7 @@ import static java.util.Arrays.deepToString;
  */
 public abstract class AbstractLicenseMojo extends AbstractMojo {
 
+  /** The license sets. */
   @Parameter
   public LicenseSet[] licenseSets;
 
@@ -177,7 +178,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
   /**
    * HeadSections define special regions of a header that allow for dynamic
-   * substitution and validation
+   * substitution and validation.
    *
    * @deprecated use {@link LicenseSet#headerSections}
    */
@@ -292,9 +293,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   @Parameter(property = "license.nThreads", defaultValue = "0")
   public int nThreads;
 
-  /**
-   * Whether to skip the plugin execution
-   */
+  /** Whether to skip the plugin execution. */
   @Parameter(property = "license.skip", defaultValue = "false")
   public boolean skip = false;
 
@@ -308,10 +307,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   @Parameter(property = "license.warnIfShallow", defaultValue = "true")
   public boolean warnIfShallow = true;
 
-  /**
-   * If you do not want to see the list of file having a missing header, you
-   * can add the quiet flag that will shorten the output
-   */
+  /** If you do not want to see the list of file having a missing header, you can add the quiet flag that will shorten the output. */
   @Parameter(property = "license.quiet", defaultValue = "false")
   public boolean quiet = false;
 
@@ -413,6 +409,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   @Component
   protected ProjectBuilder projectBuilder;
 
+  /** The session. */
   @Parameter(defaultValue = "${session}")
   public MavenSession session;
 
@@ -794,18 +791,36 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     return ex.toArray(new String[ex.size()]);
   }
 
+  /**
+   * Info.
+   *
+   * @param format the format
+   * @param params the params
+   */
   public final void info(String format, Object... params) {
     if (!quiet) {
       getLog().info(format(format, params));
     }
   }
 
+  /**
+   * Debug.
+   *
+   * @param format the format
+   * @param params the params
+   */
   public final void debug(String format, Object... params) {
     if (!quiet) {
       getLog().debug(format(format, params));
     }
   }
 
+  /**
+   * Warn.
+   *
+   * @param format the format
+   * @param params the params
+   */
   public final void warn(String format, Object... params) {
     if (!quiet) {
       getLog().warn(format(format, params));
@@ -884,10 +899,10 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
   /**
    * Retrieves the credentials for the given server or null if none could be
-   * found
+   * found.
    *
-   * @param serverID
-   * @return
+   * @param serverID the server ID
+   * @return the credentials
    */
   public Credentials findCredentials(String serverID) {
     if (serverID == null) {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Callback.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Callback.java
@@ -23,10 +23,29 @@ import com.mycila.maven.plugin.license.header.Header;
  * <b>Author:</b> Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 public interface Callback {
+
+  /**
+   * On header not found.
+   *
+   * @param document the document
+   * @param header the header
+   */
   void onHeaderNotFound(Document document, Header header);
 
+  /**
+   * On existing header.
+   *
+   * @param document the document
+   * @param header the header
+   */
   void onExistingHeader(Document document, Header header);
 
+  /**
+   * On unknown file.
+   *
+   * @param document the document
+   * @param header the header
+   */
   void onUnknownFile(Document document, Header header);
 
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Credentials.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Credentials.java
@@ -22,15 +22,31 @@ public class Credentials {
   private final String login;
   private final String password;
 
+  /**
+   * Instantiates a new credentials.
+   *
+   * @param login the login
+   * @param password the password
+   */
   public Credentials(String login, String password) {
     this.login = login;
     this.password = password;
   }
 
+  /**
+   * Gets the login.
+   *
+   * @return the login
+   */
   public String getLogin() {
     return login;
   }
 
+  /**
+   * Gets the password.
+   *
+   * @return the password
+   */
   public String getPassword() {
     return password;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -15,14 +15,19 @@
  */
 package com.mycila.maven.plugin.license;
 
+/**
+ * The Class Default.
+ */
 public final class Default {
 
   private Default() {
     // Prevent Instantiation
   }
 
+  /** The Constant INCLUDE. */
   public static final String[] INCLUDE = new String[]{"**"};
 
+  /** The Constant EXCLUDES. */
   public static final String[] EXCLUDES = {
       // Miscellaneous typical temporary files
       "**/*~",

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderSection.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderSection.java
@@ -17,6 +17,9 @@ package com.mycila.maven.plugin.license;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
+/**
+ * The Class HeaderSection.
+ */
 public class HeaderSection {
 
   /**
@@ -49,34 +52,74 @@ public class HeaderSection {
   @Parameter(defaultValue = "false")
   boolean multiLineMatch;
 
+  /**
+   * Gets the key.
+   *
+   * @return the key
+   */
   public String getKey() {
     return key;
   }
 
+  /**
+   * Sets the key.
+   *
+   * @param key the new key
+   */
   public void setKey(String key) {
     this.key = key;
   }
 
+  /**
+   * Gets the default value.
+   *
+   * @return the default value
+   */
   public String getDefaultValue() {
     return defaultValue;
   }
 
+  /**
+   * Sets the default value.
+   *
+   * @param defaultValue the new default value
+   */
   public void setDefaultValue(String defaultValue) {
     this.defaultValue = defaultValue;
   }
 
+  /**
+   * Gets the ensure match.
+   *
+   * @return the ensure match
+   */
   public String getEnsureMatch() {
     return ensureMatch;
   }
 
+  /**
+   * Sets the ensure match.
+   *
+   * @param ensureMatch the new ensure match
+   */
   public void setEnsureMatch(String ensureMatch) {
     this.ensureMatch = ensureMatch;
   }
 
+  /**
+   * Checks if is multi line match.
+   *
+   * @return true, if is multi line match
+   */
   public boolean isMultiLineMatch() {
     return multiLineMatch;
   }
 
+  /**
+   * Sets the multi line match.
+   *
+   * @param multiLineMatch the new multi line match
+   */
   public void setMultiLineMatch(boolean multiLineMatch) {
     this.multiLineMatch = multiLineMatch;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
@@ -18,11 +18,12 @@ package com.mycila.maven.plugin.license;
 import com.mycila.maven.plugin.license.header.HeaderDefinition;
 import org.apache.maven.plugins.annotations.Parameter;
 
+/**
+ * The Class HeaderStyle.
+ */
 public class HeaderStyle {
 
-  /**
-   * The name of this header style
-   */
+  /** The name of this header style. */
   @Parameter(required = true)
   public String name;
 
@@ -85,18 +86,19 @@ public class HeaderStyle {
   @Parameter
   public String skipLinePattern;
 
-  /**
-   * The regex used to detect the start of a header section or line
-   */
+  /** The regex used to detect the start of a header section or line. */
   @Parameter(required = true)
   public String firstLineDetectionPattern;
 
-  /**
-   * The regex used to detect the end of a header section or line
-   */
+  /** The regex used to detect the end of a header section or line. */
   @Parameter(required = true)
   public String lastLineDetectionPattern;
 
+  /**
+   * To header definition.
+   *
+   * @return the header definition
+   */
   public HeaderDefinition toHeaderDefinition() {
     return new HeaderDefinition(name, firstLine, beforeEachLine, endLine, afterEachLine, skipLinePattern, firstLineDetectionPattern, lastLineDetectionPattern, allowBlankLines, multiLine, padLines);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -37,14 +37,16 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 /**
- * Check if the source files of the project have a valid license header
+ * Check if the source files of the project have a valid license header.
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {
 
+  /** The error message. */
   @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header. Run license:format to update them.")
   public String errorMessage = "Some files do not have the expected license header. Run license:format to update them.";
 
+  /** The missing headers. */
   public final Collection<File> missingHeaders = new ConcurrentLinkedQueue<>();
 
   @Override

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.File;
 
 /**
- * Reformat files with a missing header to add it
+ * Reformat files with a missing header to add it.
  */
 @Mojo(name = "format", threadSafe = true)
 public final class LicenseFormatMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.File;
 
 /**
- * Remove the specified header from source files
+ * Remove the specified header from source files.
  */
 @Mojo(name = "remove", threadSafe = true)
 public final class LicenseRemoveMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
@@ -21,6 +21,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The Class LicenseSet.
+ */
 public class LicenseSet {
 
   /**
@@ -82,10 +85,7 @@ public class LicenseSet {
   @Parameter
   public HeaderStyle[] inlineHeaderStyles = new HeaderStyle[0];
 
-  /**
-   * HeadSections define special regions of a header that allow for dynamic
-   * substitution and validation
-   */
+  /** HeadSections define special regions of a header that allow for dynamic substitution and validation. */
   @Parameter
   public HeaderSection[] headerSections = new HeaderSection[0];
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Multi.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Multi.java
@@ -19,8 +19,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.Arrays;
 
+/**
+ * The Class Multi.
+ */
 public class Multi {
 
+  /** The Constant DEFAULT_SEPARATOR. */
   public static final String DEFAULT_SEPARATOR =
       "---------------------------------------------------------------------";
 
@@ -55,14 +59,29 @@ public class Multi {
   @Parameter(alias = "separator")
   String[] separators;
 
+  /**
+   * Gets the preamble.
+   *
+   * @return the preamble
+   */
   public String getPreamble() {
     return preamble;
   }
 
+  /**
+   * Sets the preamble.
+   *
+   * @param preamble the new preamble
+   */
   public void setPreamble(final String preamble) {
     this.preamble = preamble;
   }
 
+  /**
+   * Gets the headers.
+   *
+   * @return the headers
+   */
   public String[] getHeaders() {
     return headers;
   }
@@ -86,10 +105,20 @@ public class Multi {
     }
   }
 
+  /**
+   * Sets the headers.
+   *
+   * @param headers the new headers
+   */
   public void setHeaders(final String[] headers) {
     this.headers = headers;
   }
 
+  /**
+   * Gets the inline headers.
+   *
+   * @return the inline headers
+   */
   public String[] getInlineHeaders() {
     return inlineHeaders;
   }
@@ -113,10 +142,20 @@ public class Multi {
     }
   }
 
+  /**
+   * Sets the inline headers.
+   *
+   * @param inlineHeaders the new inline headers
+   */
   public void setInlineHeaders(final String[] inlineHeaders) {
     this.inlineHeaders = inlineHeaders;
   }
 
+  /**
+   * Gets the separators.
+   *
+   * @return the separators
+   */
   public String[] getSeparators() {
     return separators;
   }
@@ -140,6 +179,11 @@ public class Multi {
     }
   }
 
+  /**
+   * Sets the separators.
+   *
+   * @param separators the new separators
+   */
   public void setSeparators(final String[] separators) {
     this.separators = separators;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
@@ -23,12 +23,28 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
+ * The Interface PropertiesProvider.
  */
 public interface PropertiesProvider extends Closeable {
 
+  /**
+   * Inits the.
+   *
+   * @param mojo the mojo
+   * @param currentProperties the current properties
+   */
   default void init(AbstractLicenseMojo mojo, Map<String, String> currentProperties) {
+      // Do nothing on default
   }
 
+  /**
+   * Adjust properties.
+   *
+   * @param mojo the mojo
+   * @param currentProperties the current properties
+   * @param document the document
+   * @return the map
+   */
   default Map<String, String> adjustProperties(AbstractLicenseMojo mojo,
                                                Map<String, String> currentProperties, Document document) {
     Properties properties = new Properties();
@@ -37,6 +53,12 @@ public interface PropertiesProvider extends Closeable {
   }
 
   /**
+   * Gets the additional properties.
+   *
+   * @param mojo the mojo
+   * @param currentProperties the current properties
+   * @param document the document
+   * @return the additional properties
    * @deprecated Use instead {@link #adjustProperties(AbstractLicenseMojo, Map, Document)}
    */
   @Deprecated
@@ -45,7 +67,11 @@ public interface PropertiesProvider extends Closeable {
     return Collections.emptyMap();
   }
 
+  /**
+   * Close.
+   */
   @Override
   default void close() {
+      // Do nothing on default
   }
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Report.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Report.java
@@ -36,6 +36,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * The Class Report.
+ */
 public class Report {
 
   enum Action {CHECK, FORMAT, REMOVE}
@@ -85,6 +88,15 @@ public class Report {
   private final Map<String, Result> results = new ConcurrentHashMap<>();
   private final Path basePath;
 
+  /**
+   * Instantiates a new report.
+   *
+   * @param format the format
+   * @param action the action
+   * @param project the project
+   * @param clock the clock
+   * @param skip the skip
+   */
   public Report(String format, Action action, MavenProject project, Clock clock, boolean skip) {
     this.format = format;
     this.action = action;
@@ -100,6 +112,11 @@ public class Report {
     }
   }
 
+  /**
+   * Export to.
+   *
+   * @param reportLocation the report location
+   */
   public void exportTo(File reportLocation) {
     if (!skipped && reportLocation != null) {
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
@@ -18,15 +18,26 @@ package com.mycila.maven.plugin.license.dependencies;
 /**
  * Base class for all policy enforcer implementations.
  *
- * @param <T>
+ * @param <T> the generic type
  */
 public abstract class AbstractLicensePolicyEnforcer<T> implements LicensePolicyEnforcer<T> {
+
   private final LicensePolicy policy;
 
+  /**
+   * Instantiates a new abstract license policy enforcer.
+   *
+   * @param policy the policy
+   */
   protected AbstractLicensePolicyEnforcer(final LicensePolicy policy) {
     this.policy = policy;
   }
 
+  /**
+   * Gets the policy.
+   *
+   * @return the policy
+   */
   public LicensePolicy getPolicy() {
     return policy;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
@@ -29,8 +29,8 @@ import java.util.stream.Collectors;
  * <p>
  * Rules are applied in the following order:
  * 1) defaultPolicy: unless overridden via setDefaultPolicy, this will DENY all artifacts.
- * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule.APPROVE}
- * 3) DENY policies: any policy in the Set which have {@link LIcensePolicy.Rule.DENY}
+ * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule#APPROVE}
+ * 3) DENY policies: any policy in the Set which have {@link LicensePolicy.Rule#DENY}
  */
 @SuppressWarnings("rawtypes")
 public class AggregateLicensePolicyEnforcer {
@@ -38,6 +38,11 @@ public class AggregateLicensePolicyEnforcer {
   private LicensePolicyEnforcer defaultPolicy;
   private Set<LicensePolicyEnforcer> enforcers;
 
+  /**
+   * Instantiates a new aggregate license policy enforcer.
+   *
+   * @param policies the policies
+   */
   public AggregateLicensePolicyEnforcer(final Set<LicensePolicy> policies) {
     this.policies = policies;
     this.defaultPolicy = new DefaultLicensePolicyEnforcer();
@@ -149,28 +154,54 @@ public class AggregateLicensePolicyEnforcer {
    * applying the internal set of {@link LicensePolicyEnforcer} implementations on them,
    * and returning a mapping of Artifact keys to the boolean enforcement decision made.
    *
+   * @param licenseMap the license map
    * @return final policy decision map on each artifact
    */
   public Map<Artifact, LicensePolicyEnforcerResult> apply(final LicenseMap licenseMap) {
     return apply(licenseMap.getLicenseMap());
   }
 
+  /**
+   * Sets the enforcers.
+   *
+   * @param enforcers the new enforcers
+   */
   public void setEnforcers(final Set<LicensePolicyEnforcer> enforcers) {
     this.enforcers = enforcers;
   }
 
+  /**
+   * Gets the enforcers.
+   *
+   * @return the enforcers
+   */
   public Set<LicensePolicyEnforcer> getEnforcers() {
     return enforcers;
   }
 
+  /**
+   * Gets the policies.
+   *
+   * @return the policies
+   */
   public Set<LicensePolicy> getPolicies() {
     return policies;
   }
 
+  /**
+   * Gets the default policy.
+   *
+   * @return the default policy
+   */
   public LicensePolicyEnforcer<?> getDefaultPolicy() {
     return defaultPolicy;
   }
 
+  /**
+   * Sets the default policy.
+   *
+   * @param defaultPolicy the new default policy
+   */
   public void setDefaultPolicy(final LicensePolicyEnforcer defaultPolicy) {
     this.defaultPolicy = defaultPolicy;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/ArtifactLicensePolicyEnforcer.java
@@ -27,11 +27,22 @@ import java.util.Collections;
 public class ArtifactLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<Artifact> {
   private ArtifactFilter filter;
 
+  /**
+   * Instantiates a new artifact license policy enforcer.
+   *
+   * @param policy the policy
+   * @param filter the filter
+   */
   public ArtifactLicensePolicyEnforcer(final LicensePolicy policy, final ArtifactFilter filter) {
     super(policy);
     this.filter = filter;
   }
 
+  /**
+   * Instantiates a new artifact license policy enforcer.
+   *
+   * @param policy the policy
+   */
   public ArtifactLicensePolicyEnforcer(final LicensePolicy policy) {
     super(policy);
     this.filter = new StrictPatternIncludesArtifactFilter(Collections.singletonList(policy.getValue()));

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/DefaultLicensePolicyEnforcer.java
@@ -20,6 +20,9 @@ package com.mycila.maven.plugin.license.dependencies;
  */
 public class DefaultLicensePolicyEnforcer extends ArtifactLicensePolicyEnforcer {
 
+  /**
+   * Instantiates a new default license policy enforcer.
+   */
   public DefaultLicensePolicyEnforcer() {
     super(new LicensePolicy(LicensePolicy.Rule.DENY, LicensePolicy.Type.ARTIFACT_PATTERN, "*"));
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMap.java
@@ -27,5 +27,10 @@ import java.util.Set;
  */
 public interface LicenseMap {
 
+  /**
+   * Gets the license map.
+   *
+   * @return the license map
+   */
   Map<License, Set<Artifact>> getLicenseMap();
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseMessage.java
@@ -19,7 +19,13 @@ package com.mycila.maven.plugin.license.dependencies;
  * Expose message text to config and tests.
  */
 public interface LicenseMessage {
+
+  /** The warn policy denied. */
   String WARN_POLICY_DENIED = "Some licenses were denied by policy:";
+
+  /** The info license impl. */
   String INFO_LICENSE_IMPL = "Checking licenses in dependencies using";
+
+  /** The info deps discovered. */
   String INFO_DEPS_DISCOVERED = "Discovered dependencies after filtering";
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseNameLicensePolicyEnforcer.java
@@ -22,6 +22,11 @@ import org.apache.maven.model.License;
  */
 public class LicenseNameLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
 
+  /**
+   * Instantiates a new license name license policy enforcer.
+   *
+   * @param policy the policy
+   */
   public LicenseNameLicensePolicyEnforcer(final LicensePolicy policy) {
     super(policy);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
@@ -24,12 +24,32 @@ import java.util.Optional;
  * enforcers should take this class as a constructor argument.
  */
 public class LicensePolicy {
+
+  /**
+   * The Enum Type.
+   */
   public enum Type {
-    LICENSE_NAME, LICENSE_URL, ARTIFACT_PATTERN;
+    /** The license name. */
+    LICENSE_NAME,
+
+    /** The license url. */
+    LICENSE_URL,
+
+    /** The artifact pattern. */
+    ARTIFACT_PATTERN;
   }
 
+  /**
+   * The Enum Rule.
+   */
   public enum Rule {
-    APPROVE(true), DENY(false);
+
+    /** The approve. */
+    APPROVE(true),
+
+    /** The deny. */
+    DENY(false);
+
     boolean allowed;
 
     Rule(final boolean allowed) {
@@ -39,7 +59,7 @@ public class LicensePolicy {
     /**
      * Get a boolean form of a rule.
      *
-     * @return
+     * @return the predicate
      */
     public boolean getPredicate() {
       return allowed;
@@ -55,6 +75,12 @@ public class LicensePolicy {
       return matched == allowed;
     }
 
+    /**
+     * Value of.
+     *
+     * @param allowed the allowed
+     * @return the rule
+     */
     public static Rule valueOf(final boolean allowed) {
       if (allowed) {
         return APPROVE;
@@ -71,10 +97,20 @@ public class LicensePolicy {
   @Parameter
   private String value;
 
+  /**
+   * Instantiates a new license policy.
+   */
   // only here for plexus container injection by maven
   public LicensePolicy() {
   }
 
+  /**
+   * Instantiates a new license policy.
+   *
+   * @param rule the rule
+   * @param type the type
+   * @param value the value
+   */
   public LicensePolicy(final Rule rule, final Type type, final String value) {
     this.setRule(rule);
     this.setType(type);
@@ -95,14 +131,29 @@ public class LicensePolicy {
     }
   }
 
+  /**
+   * Gets the value.
+   *
+   * @return the value
+   */
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets the rule.
+   *
+   * @return the rule
+   */
   public Rule getRule() {
     return rule;
   }
 
+  /**
+   * Gets the type.
+   *
+   * @return the type
+   */
   public Type getType() {
     return type;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcer.java
@@ -17,12 +17,30 @@ package com.mycila.maven.plugin.license.dependencies;
 
 /**
  * Methods exposed by enforcer implementations using {@link LicensePolicy}.
+ *
+ * @param <T> the generic type
  */
 public interface LicensePolicyEnforcer<T> {
 
+  /**
+   * Gets the policy.
+   *
+   * @return the policy
+   */
   public LicensePolicy getPolicy();
 
+  /**
+   * Apply.
+   *
+   * @param target the target
+   * @return true, if successful
+   */
   public boolean apply(final T target);
 
+  /**
+   * Gets the type.
+   *
+   * @return the type
+   */
   public Class<?> getType();
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResult.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicyEnforcerResult.java
@@ -18,6 +18,9 @@ package com.mycila.maven.plugin.license.dependencies;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.License;
 
+/**
+ * The Class LicensePolicyEnforcerResult.
+ */
 public class LicensePolicyEnforcerResult {
 
   private final LicensePolicy policy;
@@ -25,6 +28,14 @@ public class LicensePolicyEnforcerResult {
   private final Artifact artifact;
   private final LicensePolicy.Rule ruling;
 
+  /**
+   * Instantiates a new license policy enforcer result.
+   *
+   * @param policy the policy
+   * @param license the license
+   * @param artifact the artifact
+   * @param ruling the ruling
+   */
   public LicensePolicyEnforcerResult(final LicensePolicy policy, final License license, final Artifact artifact, final LicensePolicy.Rule ruling) {
     this.policy = policy;
     this.license = license;
@@ -46,22 +57,47 @@ public class LicensePolicyEnforcerResult {
     }
   }
 
+  /**
+   * Gets the policy.
+   *
+   * @return the policy
+   */
   public LicensePolicy getPolicy() {
     return policy;
   }
 
+  /**
+   * Gets the artifact.
+   *
+   * @return the artifact
+   */
   public Artifact getArtifact() {
     return artifact;
   }
 
+  /**
+   * Checks if is allowed.
+   *
+   * @return the boolean
+   */
   public Boolean isAllowed() {
     return ruling.getPredicate();
   }
 
+  /**
+   * Gets the ruling.
+   *
+   * @return the ruling
+   */
   public LicensePolicy.Rule getRuling() {
     return ruling;
   }
 
+  /**
+   * Gets the license.
+   *
+   * @return the license
+   */
   public License getLicense() {
     return license;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicenseURLLicensePolicyEnforcer.java
@@ -22,6 +22,11 @@ import org.apache.maven.model.License;
  */
 public class LicenseURLLicensePolicyEnforcer extends AbstractLicensePolicyEnforcer<License> {
 
+  /**
+   * Instantiates a new license URL license policy enforcer.
+   *
+   * @param policy the policy
+   */
   public LicenseURLLicensePolicyEnforcer(final LicensePolicy policy) {
     super(policy);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
@@ -74,9 +74,14 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
   }
 
   /**
+   * Instantiates a new maven project licenses.
+   *
    * @param session        the current {@link MavenSession}
+   * @param project the project
    * @param graph          the {@link DependencyGraphBuilder} implementation
    * @param projectBuilder the maven {@link ProjectBuilder} implementation
+   * @param scopes the scopes
+   * @param log the log
    */
   public MavenProjectLicenses(final MavenSession session, MavenProject project, final DependencyGraphBuilder graph,
                               final ProjectBuilder projectBuilder, final List<String> scopes, final Log log) {
@@ -85,6 +90,9 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
 
   /**
    * Return a set of licenses attributed to a single artifact.
+   *
+   * @param artifact the artifact
+   * @return the licenses from artifact
    */
   protected Set<License> getLicensesFromArtifact(final Artifact artifact) {
     Set<License> licenses = new HashSet<>();
@@ -127,6 +135,8 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
 
   /**
    * Return the Set of all direct and transitive Artifact dependencies.
+   *
+   * @return the dependencies
    */
   private Set<Artifact> getDependencies() {
     final Set<Artifact> artifacts = new HashSet<>();
@@ -159,6 +169,11 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
     // return project.getArtifacts();
   }
 
+  /**
+   * Gets the projects.
+   *
+   * @return the projects
+   */
   protected Set<MavenProject> getProjects() {
     return projects;
   }
@@ -167,6 +182,11 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
     this.session = session;
   }
 
+  /**
+   * Sets the projects.
+   *
+   * @param projects the new projects
+   */
   protected void setProjects(final Set<MavenProject> projects) {
     this.projects = Optional.ofNullable(projects).orElse(new HashSet<>());
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/Document.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/Document.java
@@ -41,6 +41,15 @@ public final class Document {
   private HeaderParser parser;
 
 
+  /**
+   * Instantiates a new document.
+   *
+   * @param file the file
+   * @param headerDefinition the header definition
+   * @param encoding the encoding
+   * @param keywords the keywords
+   * @param documentPropertiesLoader the document properties loader
+   */
   public Document(File file, HeaderDefinition headerDefinition, String encoding, String[] keywords, DocumentPropertiesLoader documentPropertiesLoader) {
     this.keywords = keywords.clone();
     this.file = file;
@@ -49,26 +58,58 @@ public final class Document {
     this.documentPropertiesLoader = documentPropertiesLoader;
   }
 
+  /**
+   * Gets the header definition.
+   *
+   * @return the header definition
+   */
   public HeaderDefinition getHeaderDefinition() {
     return headerDefinition;
   }
 
+  /**
+   * Gets the file.
+   *
+   * @return the file
+   */
   public File getFile() {
     return file;
   }
 
+  /**
+   * Gets the file path.
+   *
+   * @return the file path
+   */
   public String getFilePath() {
     return getFile().getPath().replace('\\', '/');
   }
 
+  /**
+   * Gets the encoding.
+   *
+   * @return the encoding
+   */
   public String getEncoding() {
     return encoding;
   }
 
+  /**
+   * Checks if is not supported.
+   *
+   * @return true, if is not supported
+   */
   public boolean isNotSupported() {
     return headerDefinition == null || HeaderType.UNKNOWN.getDefinition().getType().equals(headerDefinition.getType());
   }
 
+  /**
+   * Checks for header.
+   *
+   * @param header the header
+   * @param strictCheck the strict check
+   * @return true, if successful
+   */
   public boolean hasHeader(Header header, boolean strictCheck) {
     if (!strictCheck) {
       try {
@@ -87,19 +128,38 @@ public final class Document {
     }
   }
 
+  /**
+   * Update header.
+   *
+   * @param header the header
+   */
   public void updateHeader(Header header) {
     String headerStr = header.applyDefinitionAndSections(parser.getHeaderDefinition(), parser.getFileContent().isUnix());
     parser.getFileContent().insert(parser.getBeginPosition(), mergeProperties(headerStr));
   }
 
+  /**
+   * Merge properties.
+   *
+   * @param str the str
+   * @return the string
+   */
   public String mergeProperties(String str) {
     return placeholderResolver.replacePlaceholders(str, documentPropertiesLoader.load(this));
   }
 
+  /**
+   * Save.
+   */
   public void save() {
     saveTo(file);
   }
 
+  /**
+   * Save to.
+   *
+   * @param dest the dest
+   */
   public void saveTo(File dest) {
     if (parser != null) {
       try {
@@ -110,16 +170,30 @@ public final class Document {
     }
   }
 
+  /**
+   * Gets the content.
+   *
+   * @return the content
+   */
   public String getContent() {
     return parser == null ? "" : parser.getFileContent().getContent();
   }
 
+  /**
+   * Removes the header.
+   */
   public void removeHeader() {
     if (headerDetected()) {
       parser.getFileContent().delete(parser.getBeginPosition(), parser.getEndPosition());
     }
   }
 
+  /**
+   * Checks if is.
+   *
+   * @param header the header
+   * @return true, if successful
+   */
   public boolean is(Header header) {
     try {
       return header.getLocation().isFromUrl(this.file.toURI().toURL());
@@ -128,12 +202,20 @@ public final class Document {
     }
   }
 
+  /**
+   * Parses the header.
+   */
   public void parseHeader() {
     if (parser == null) {
       parser = new HeaderParser(new FileContent(file, encoding), headerDefinition, keywords);
     }
   }
 
+  /**
+   * Header detected.
+   *
+   * @return true, if successful
+   */
   public boolean headerDetected() {
     return parser.gotAnyHeader();
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
@@ -33,6 +33,16 @@ public final class DocumentFactory {
   private final String[] keywords;
   private final DocumentPropertiesLoader documentPropertiesLoader;
 
+  /**
+   * Instantiates a new document factory.
+   *
+   * @param basedir the basedir
+   * @param mapping the mapping
+   * @param definitions the definitions
+   * @param encoding the encoding
+   * @param keywords the keywords
+   * @param documentPropertiesLoader the document properties loader
+   */
   public DocumentFactory(final File basedir, final Map<String, String> mapping, final Map<String, HeaderDefinition> definitions, final String encoding, final String[] keywords, final DocumentPropertiesLoader documentPropertiesLoader) {
     this.mapping = mapping;
     this.definitions = definitions;
@@ -42,6 +52,12 @@ public final class DocumentFactory {
     this.documentPropertiesLoader = documentPropertiesLoader;
   }
 
+  /**
+   * Creates a new Document object.
+   *
+   * @param file the file
+   * @return the document
+   */
   public Document createDocuments(final String file) {
     return getWrapper(file);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentPropertiesLoader.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentPropertiesLoader.java
@@ -17,7 +17,16 @@ package com.mycila.maven.plugin.license.document;
 
 import java.util.Map;
 
+/**
+ * The Interface DocumentPropertiesLoader.
+ */
 public interface DocumentPropertiesLoader {
 
+  /**
+   * Load.
+   *
+   * @param d the d
+   * @return the map
+   */
   Map<String, String> load(Document d);
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
@@ -28,87 +28,243 @@ import java.util.Map;
 public enum DocumentType {
   ////////// Document types ordered alphabetically //////////
 
+  /** The actionscript. */
   ACTIONSCRIPT("as", HeaderType.JAVADOC_STYLE),
+
+  /** The ada body. */
   ADA_BODY("adb", HeaderType.DOUBLEDASHES_STYLE),
+
+  /** The ada spec. */
   ADA_SPEC("ads", HeaderType.DOUBLEDASHES_STYLE),
+
+  /** The ascii doc. */
   ASCII_DOC("adoc", HeaderType.ASCIIDOC_STYLE),
+
+  /** The asp. */
   ASP("asp", HeaderType.ASP),
+
+  /** The aspectj. */
   ASPECTJ("aj", HeaderType.JAVADOC_STYLE),
+
+  /** The assembler. */
   ASSEMBLER("asm", HeaderType.SEMICOLON_STYLE),
+
+  /** The c. */
   C("c", HeaderType.JAVADOC_STYLE),
+
+  /** The clojure. */
   CLOJURE("clj", HeaderType.SEMICOLON_STYLE),
+
+  /** The clojurescript. */
   CLOJURESCRIPT("cljs", HeaderType.SEMICOLON_STYLE),
+
+  /** The coldfusion component. */
   COLDFUSION_COMPONENT("cfc", HeaderType.DYNASCRIPT3_STYLE),
+
+  /** The coldfusion ml. */
   COLDFUSION_ML("cfm", HeaderType.DYNASCRIPT3_STYLE),
+
+  /** The cpp. */
   CPP("cpp", HeaderType.JAVADOC_STYLE),
+
+  /** The csharp. */
   CSHARP("cs", HeaderType.JAVADOC_STYLE),
+
+  /** The css. */
   CSS("css", HeaderType.JAVADOC_STYLE),
+
+  /** The delphi. */
   DELPHI("pas", HeaderType.BRACESSTAR_STYLE),
+
+  /** The dockerfile. */
   DOCKERFILE("Dockerfile", HeaderType.SCRIPT_STYLE),
+
+  /** The doxia apt. */
   DOXIA_APT("apt", HeaderType.DOUBLETILDE_STYLE),
+
+  /** The doxia faq. */
   DOXIA_FAQ("fml", HeaderType.XML_STYLE),
+
+  /** The dtd. */
   DTD("dtd", HeaderType.XML_STYLE),
+
+  /** The editorconfig. */
   EDITORCONFIG(".editorconfig", HeaderType.SCRIPT_STYLE),
+
+  /** The eiffel. */
   EIFFEL("e", HeaderType.DOUBLEDASHES_STYLE),
+
+  /** The erlang. */
   ERLANG("erl", HeaderType.PERCENT3_STYLE),
+
+  /** The erlang header. */
   ERLANG_HEADER("hrl", HeaderType.PERCENT3_STYLE),
+
+  /** The fortran. */
   FORTRAN("f", HeaderType.EXCLAMATION_STYLE),
+
+  /** The freemarker. */
   FREEMARKER("ftl", HeaderType.FTL),
+
+  /** The groovy. */
   GROOVY("groovy", HeaderType.SLASHSTAR_STYLE),
+
+  /** The gsp. */
   GSP("GSP", HeaderType.XML_STYLE),
+
+  /** The h. */
   H("h", HeaderType.JAVADOC_STYLE),
+
+  /** The haml. */
   HAML("haml", HeaderType.HAML_STYLE),
+
+  /** The htm. */
   HTM("htm", HeaderType.XML_STYLE),
+
+  /** The html. */
   HTML("html", HeaderType.XML_STYLE),
+
+  /** The java. */
   JAVA("java", HeaderType.SLASHSTAR_STYLE),
+
+  /** The javafx. */
   JAVAFX("fx", HeaderType.SLASHSTAR_STYLE),
+
+  /** The javascript. */
   JAVASCRIPT("js", HeaderType.SLASHSTAR_STYLE),
+
+  /** The jsp. */
   JSP("jsp", HeaderType.DYNASCRIPT_STYLE),
+
+  /** The jspx. */
   JSPX("jspx", HeaderType.XML_STYLE),
+
+  /** The kml. */
   KML("kml", HeaderType.XML_STYLE),
+
+  /** The kotlin. */
   KOTLIN("kt", HeaderType.SLASHSTAR_STYLE),
+
+  /** The lisp. */
   LISP("el", HeaderType.EXCLAMATION3_STYLE),
+
+  /** The lua. */
   LUA("lua", HeaderType.LUA),
+
+  /** The mustache. */
   MUSTACHE("mustache", HeaderType.MUSTACHE_STYLE),
+
+  /** The mvel. */
   MVEL("mv", HeaderType.MVEL_STYLE),
+
+  /** The mxml. */
   MXML("mxml", HeaderType.XML_STYLE),
+
+  /** The perl. */
   PERL("pl", HeaderType.SCRIPT_STYLE),
+
+  /** The perl module. */
   PERL_MODULE("pm", HeaderType.SCRIPT_STYLE),
+
+  /** The php. */
   PHP("php", HeaderType.PHP),
+
+  /** The pom. */
   POM("pom", HeaderType.XML_STYLE),
+
+  /** The properties. */
   PROPERTIES("properties", HeaderType.SCRIPT_STYLE),
+
+  /** The python. */
   PYTHON("py", HeaderType.SCRIPT_STYLE),
+
+  /** The ruby. */
   RUBY("rb", HeaderType.SCRIPT_STYLE),
+
+  /** The scala. */
   SCALA("scala", HeaderType.SLASHSTAR_STYLE),
+
+  /** The scaml. */
   SCAML("scaml", HeaderType.HAML_STYLE),
+
+  /** The scss. */
   SCSS("scss", HeaderType.JAVADOC_STYLE),
+
+  /** The shell. */
   SHELL("sh", HeaderType.SCRIPT_STYLE),
+
+  /** The spring factories. */
   SPRING_FACTORIES("spring.factories", HeaderType.SCRIPT_STYLE),
+
+  /** The sql. */
   SQL("sql", HeaderType.DOUBLEDASHES_STYLE),
+
+  /** The tagx. */
   TAGX("tagx", HeaderType.XML_STYLE),
+
+  /** The tex class. */
   TEX_CLASS("cls", HeaderType.PERCENT_STYLE),
+
+  /** The tex style. */
   TEX_STYLE("sty", HeaderType.PERCENT_STYLE),
+
+  /** The tex. */
   TEX("tex", HeaderType.PERCENT_STYLE),
+
+  /** The tld. */
   TLD("tld", HeaderType.XML_STYLE),
+
+  /** The ts. */
   TS("ts", HeaderType.TRIPLESLASH_STYLE),
+
+  /** The txt. */
   TXT("txt", HeaderType.TEXT),
+
+  /** The unknown. */
   UNKNOWN("", HeaderType.UNKNOWN),
+
+  /** The vb. */
   VB("bas", HeaderType.HAML_STYLE),
+
+  /** The vba. */
   VBA("vba", HeaderType.APOSTROPHE_STYLE),
+
+  /** The velocity. */
   VELOCITY("vm", HeaderType.SHARPSTAR_STYLE),
+
+  /** The windows batch. */
   WINDOWS_BATCH("bat", HeaderType.BATCH),
+
+  /** The windows shell. */
   WINDOWS_SHELL("cmd", HeaderType.BATCH),
+
+  /** The wsdl. */
   WSDL("wsdl", HeaderType.XML_STYLE),
+
+  /** The xhtml. */
   XHTML("xhtml", HeaderType.XML_STYLE),
+
+  /** The xml. */
   XML("xml", HeaderType.XML_STYLE),
+
+  /** The xsd. */
   XSD("xsd", HeaderType.XML_STYLE),
+
+  /** The xsl. */
   XSL("xsl", HeaderType.XML_STYLE),
+
+  /** The xslt. */
   XSLT("xslt", HeaderType.XML_STYLE),
+
+  /** The yaml. */
   YAML("yaml", HeaderType.SCRIPT_STYLE),
+
+  /** The yml. */
   YML("yml", HeaderType.SCRIPT_STYLE);
 
   ////////////////////////////////////
 
+  /** The Constant MAPPING. */
   private static final Map<String, String> MAPPING = new LinkedHashMap<>(values().length);
 
   static {
@@ -117,26 +273,55 @@ public enum DocumentType {
     }
   }
 
+  /** The extension. */
   private final String extension;
+
+  /** The default header type. */
   private final HeaderType defaultHeaderType;
 
+  /**
+   * Instantiates a new document type.
+   *
+   * @param extension the extension
+   * @param defaultHeaderType the default header type
+   */
   private DocumentType(String extension, HeaderType defaultHeaderType) {
     this.extension = extension;
     this.defaultHeaderType = defaultHeaderType;
   }
 
+  /**
+   * Gets the extension.
+   *
+   * @return the extension
+   */
   public String getExtension() {
     return extension;
   }
 
+  /**
+   * Gets the default header type.
+   *
+   * @return the default header type
+   */
   public HeaderType getDefaultHeaderType() {
     return defaultHeaderType;
   }
 
+  /**
+   * Gets the default header type name.
+   *
+   * @return the default header type name
+   */
   public String getDefaultHeaderTypeName() {
     return defaultHeaderType.name().toLowerCase();
   }
 
+  /**
+   * Default mapping.
+   *
+   * @return the map
+   */
   public static Map<String, String> defaultMapping() {
     return Collections.unmodifiableMap(MAPPING);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/PropertyPlaceholderResolver.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/PropertyPlaceholderResolver.java
@@ -37,6 +37,13 @@ class PropertyPlaceholderResolver {
   private final String placeholderPrefix = "${";
   private final String placeholderSuffix = "}";
 
+  /**
+   * Replace placeholders.
+   *
+   * @param value the value
+   * @param properties the properties
+   * @return the string
+   */
   public String replacePlaceholders(String value, final Map<String, String> properties) {
     return replacePlaceholders(value, properties::get);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/Header.java
@@ -71,18 +71,38 @@ public final class Header {
     this.maxLength = maxLength;
   }
 
+  /**
+   * As string.
+   *
+   * @return the string
+   */
   public String asString() {
     return headerContent;
   }
 
+  /**
+   * As one line string.
+   *
+   * @return the string
+   */
   public String asOneLineString() {
     return headerContentOneLine;
   }
 
+  /**
+   * Gets the line count.
+   *
+   * @return the line count
+   */
   public int getLineCount() {
     return lines.length;
   }
 
+  /**
+   * Gets the max line length.
+   *
+   * @return the max line length
+   */
   public int getMaxLineLength() {
     return maxLength;
   }
@@ -96,10 +116,23 @@ public final class Header {
     return location;
   }
 
+  /**
+   * Eol.
+   *
+   * @param unix the unix
+   * @return the string
+   */
   public String eol(boolean unix) {
     return unix ? "\n" : "\r\n";
   }
 
+  /**
+   * Builds the for definition.
+   *
+   * @param type the type
+   * @param unix the unix
+   * @return the string
+   */
   public String buildForDefinition(HeaderDefinition type, boolean unix) {
     StringBuilder newHeader = new StringBuilder();
     String unixEndOfLine = eol(unix);
@@ -139,6 +172,11 @@ public final class Header {
     return asString();
   }
 
+  /**
+   * Gets the lines.
+   *
+   * @return the lines
+   */
   public String[] getLines() {
     return lines;
   }
@@ -159,6 +197,15 @@ public final class Header {
     return isMatchForText(expected, potentialFileHeader, headerDefinition, unix);
   }
 
+  /**
+   * Checks if is match for text.
+   *
+   * @param expected the expected
+   * @param potentialFileHeader the potential file header
+   * @param headerDefinition the header definition
+   * @param unix the unix
+   * @return true, if is match for text
+   */
   public boolean isMatchForText(String expected, String potentialFileHeader, HeaderDefinition headerDefinition, boolean unix) {
 
     SortedMap<Integer, HeaderSection> sectionsByIndex = computeSectionsByIndex(expected);
@@ -172,6 +219,16 @@ public final class Header {
     return recursivelyFindMatch(potentialFileHeader, headerDefinition, textBetweenSections, sectionsInOrder, 0, 0);
   }
 
+  /**
+   * Checks if is match for text.
+   *
+   * @param d the d
+   * @param headerDefinition the header definition
+   * @param unix the unix
+   * @param encoding the encoding
+   * @return true, if is match for text
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   public boolean isMatchForText(Document d, HeaderDefinition headerDefinition, boolean unix, String encoding) throws IOException {
     String fileHeader = readFirstLines(d.getFile(), getLineCount() + 10, encoding).replaceAll(" *\r?\n", "\n");
     String expected = buildForDefinition(headerDefinition, unix);
@@ -179,6 +236,13 @@ public final class Header {
     return isMatchForText(expected, fileHeader, headerDefinition, unix);
   }
 
+  /**
+   * Apply definition and sections.
+   *
+   * @param headerDefinition the header definition
+   * @param unix the unix
+   * @return the string
+   */
   public String applyDefinitionAndSections(HeaderDefinition headerDefinition, boolean unix) {
 
     String expected = buildForDefinition(headerDefinition, unix);

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
@@ -51,6 +51,9 @@ public final class HeaderDefinition {
    *                                  if it can be outputted from the line of the file.
    * @param firstLineDetectionPattern The pattern to detect the first line of a previous header.
    * @param lastLineDetectionPattern  The pattern to detect the last line of a previous header.
+   * @param allowBlankLines the allow blank lines
+   * @param multiLine the multi line
+   * @param padLines the pad lines
    * @throws IllegalArgumentException If the type name is null.
    */
   public HeaderDefinition(String type,
@@ -98,30 +101,65 @@ public final class HeaderDefinition {
     return regexp == null ? null : Pattern.compile(regexp);
   }
 
+  /**
+   * Gets the first line.
+   *
+   * @return the first line
+   */
   public String getFirstLine() {
     return firstLine;
   }
 
+  /**
+   * Gets the before each line.
+   *
+   * @return the before each line
+   */
   public String getBeforeEachLine() {
     return beforeEachLine;
   }
 
+  /**
+   * Gets the end line.
+   *
+   * @return the end line
+   */
   public String getEndLine() {
     return endLine;
   }
 
+  /**
+   * Gets the after each line.
+   *
+   * @return the after each line
+   */
   public String getAfterEachLine() {
     return afterEachLine;
   }
 
+  /**
+   * Gets the type.
+   *
+   * @return the type
+   */
   public String getType() {
     return type;
   }
 
+  /**
+   * Allow blank lines.
+   *
+   * @return true, if successful
+   */
   public boolean allowBlankLines() {
     return allowBlankLines;
   }
 
+  /**
+   * Checks if is pad lines.
+   *
+   * @return true, if is pad lines
+   */
   public boolean isPadLines() {
     return padLines;
   }
@@ -157,6 +195,11 @@ public final class HeaderDefinition {
     return lastLineDetectionPattern != null && line != null && lastLineDetectionPattern.matcher(line).matches();
   }
 
+  /**
+   * Gets the skip line pattern.
+   *
+   * @return the skip line pattern
+   */
   protected Pattern getSkipLinePattern() {
     return skipLinePattern;
   }
@@ -259,6 +302,11 @@ public final class HeaderDefinition {
     return type;
   }
 
+  /**
+   * Checks if is multi line.
+   *
+   * @return true, if is multi line
+   */
   public boolean isMultiLine() {
     return multiLine;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
@@ -45,6 +45,7 @@ public final class HeaderParser {
    *
    * @param fileContent      The file content.
    * @param headerDefinition The associated header definition to use.
+   * @param keywords the keywords
    * @throws IllegalArgumentException If the file content is null or if the header definition is null.
    */
   public HeaderParser(FileContent fileContent, HeaderDefinition headerDefinition, String[] keywords) {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
@@ -34,6 +34,12 @@ public abstract class HeaderSource {
    * A {@link HeaderSource} built from a license header template literal.
    */
   public static class LiteralHeaderSource extends HeaderSource {
+
+    /**
+     * Instantiates a new literal header source.
+     *
+     * @param content the content
+     */
     public LiteralHeaderSource(String content) {
       super(content, true);
     }
@@ -59,6 +65,13 @@ public abstract class HeaderSource {
   public static class UrlHeaderSource extends HeaderSource {
     private final URL url;
 
+    /**
+     * Instantiates a new url header source.
+     *
+     * @param url the url
+     * @param encoding the encoding
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
     public UrlHeaderSource(URL url, String encoding) throws IOException {
       super(FileUtils.read(url, encoding), false);
       this.url = url;
@@ -80,6 +93,14 @@ public abstract class HeaderSource {
    * A {@link HeaderSource} built from multiple license header template literals.
    */
   public static class MultiLiteralHeaderSource extends HeaderSource {
+
+    /**
+     * Instantiates a new multi literal header source.
+     *
+     * @param preamble the preamble
+     * @param contents the contents
+     * @param separators the separators
+     */
     public MultiLiteralHeaderSource(final String preamble, final String[] contents, final String[] separators) {
       super(combineHeaders(preamble, contents, separators), true);
     }
@@ -105,6 +126,15 @@ public abstract class HeaderSource {
   public static class MultiUrlHeaderSource extends HeaderSource {
     private final URL[] urls;
 
+    /**
+     * Instantiates a new multi url header source.
+     *
+     * @param preamble the preamble
+     * @param urls the urls
+     * @param separators the separators
+     * @param encoding the encoding
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
     public MultiUrlHeaderSource(final String preamble, final URL[] urls, final String[] separators, final String encoding) throws IOException {
       super(combineHeaders(preamble, FileUtils.read(urls, encoding), separators), false);
       this.urls = urls;
@@ -180,6 +210,14 @@ public abstract class HeaderSource {
     return builder.toString();
   }
 
+  /**
+   * Of.
+   *
+   * @param headerPath the header path
+   * @param encoding the encoding
+   * @param finder the finder
+   * @return the header source
+   */
   public static HeaderSource of(String headerPath, String encoding, ResourceFinder finder) {
     return of(null, encoding, finder);
   }
@@ -238,9 +276,17 @@ public abstract class HeaderSource {
     }
   }
 
+  /** The content. */
   protected final String content;
+
   private final boolean inline;
 
+  /**
+   * Instantiates a new header source.
+   *
+   * @param content the content
+   * @param inline the inline
+   */
   protected HeaderSource(String content, boolean inline) {
     super();
     this.content = content;
@@ -248,6 +294,8 @@ public abstract class HeaderSource {
   }
 
   /**
+   * Gets the content.
+   *
    * @return the text of the license template
    */
   public String getContent() {
@@ -255,6 +303,8 @@ public abstract class HeaderSource {
   }
 
   /**
+   * Checks if is inline.
+   *
    * @return {@code true} if this {@link HeaderSource} was created from a string rather by loading the bits from an
    * URL; {@code false} otherwise
    */

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
@@ -25,51 +25,114 @@ import java.util.Map;
  * @see com.mycila.maven.plugin.license.header.HeaderDefinition
  */
 public enum HeaderType {
-  ////////// COMMENT TYPES //////////
-  ////////// COMMENT TYPES //////////
 
-  //              firstLine   beforeEachLine   endLine   afterEachLine   skipLinePattern   firstLineDetectionPattern   lastLineDetectionPattern   allowBlankLines   multiLine   padLines
-  //generic
+  // Comment Type (firstLine, beforeEachLine, endLine, afterEachLine, skipLinePattern, firstLineDetectionPattern, lastLineDetectionPattern, allowBlankLines, multiLine, padLines)
+
+  /** The asciidoc style. */
   ASCIIDOC_STYLE("////", "  // ", "////EOL", "", null, "^////$", "^////$", false, true, false),
+
+  /** The mvel style. */
   MVEL_STYLE("@comment{", "  ", "}", "", null, "@comment\\{$", "\\}$", true, true, false),
+
+  /** The javadoc style. */
   JAVADOC_STYLE("/**", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+
+  /** The scala style. */
   SCALA_STYLE("/**", "  * ", "  */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+
+  /** The javapkg style. */
   JAVAPKG_STYLE("EOL/*-", " * ", " */", "", "^package [a-z_]+(\\.[a-z_][a-z0-9_]*)*;$", "(EOL)*(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+
+  /** The script style. */
   SCRIPT_STYLE("#", "# ", "#EOL", "", "^#!.*$", "#.*$", "#.*$", false, false, false),
+
+  /** The haml style. */
   HAML_STYLE("-#", "-# ", "-#EOL", "", "^-#!.*$", "-#.*$", "-#.*$", false, false, false),
+
+  /** The xml style. */
   XML_STYLE("<!--EOL", "    ", "EOL-->", "", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", true, true, false),
+
+  /** The xml per line. */
   XML_PER_LINE("EOL", "<!-- ", "EOL", " -->", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", false, false, true),
+
+  /** The semicolon style. */
   SEMICOLON_STYLE(";", "; ", ";EOL", "", null, ";.*$", ";.*$", false, false, false),
+
+  /** The apostrophe style. */
   APOSTROPHE_STYLE("'", "' ", "'EOL", "", null, "'.*$", "'.*$", false, false, false),
+
+  /** The exclamation style. */
   EXCLAMATION_STYLE("!", "! ", "!EOL", "", null, "!.*$", "!.*$", false, false, false),
+
+  /** The doubledashes style. */
   DOUBLEDASHES_STYLE("--", "-- ", "--EOL", "", null, "--.*$", "--.*$", false, false, false),
+
+  /** The slashstar style. */
   SLASHSTAR_STYLE("/*", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+
+  /** The bracesstar style. */
   BRACESSTAR_STYLE("{*", " * ", " *}", "", null, "(\\s|\\t)*\\{\\*.*$", ".*\\*\\}(\\s|\\t)*$", false, true, false),
+
+  /** The sharpstar style. */
   SHARPSTAR_STYLE("#*", " * ", " *#", "", null, "(\\s|\\t)*#\\*.*$", ".*\\*#(\\s|\\t)*$", false, true, false),
+
+  /** The doubletilde style. */
   DOUBLETILDE_STYLE("~~", "~~ ", "~~EOL", "", null, "~~.*$", "~~.*$", false, false, false),
+
+  /** The dynascript style. */
   DYNASCRIPT_STYLE("<%--EOL", "    ", "EOL--%>", "", null, "(\\s|\\t)*<%--.*$", ".*--%>(\\s|\\t)*$", true, true, false),
+
+  /** The dynascript3 style. */
   DYNASCRIPT3_STYLE("<!---EOL", "    ", "EOL--->", "", null, "(\\s|\\t)*<!---.*$", ".*--->(\\s|\\t)*$", true, true, false),
+
+  /** The percent style. */
   PERCENT_STYLE("", "% ", "EOL", "", null, "^% .*$", "^% .*$", false, false, false),
+
+  /** The percent3 style. */
   PERCENT3_STYLE("%%%", "%%% ", "%%%EOL", "", null, "%%%.*$", "%%%.*$", false, false, false),
+
+  /** The exclamation3 style. */
   EXCLAMATION3_STYLE("!!!", "!!! ", "!!!EOL", "", null, "!!!.*$", "!!!.*$", false, false, false),
 
+  /** The doubleslash style. */
   DOUBLESLASH_STYLE("//", "// ", "//EOL", "", null, "//.*$", "//.*$", false, false, false),
+
+  /** The single line doubleslash style. */
   SINGLE_LINE_DOUBLESLASH_STYLE("", "// ", "", "", null, "//.*$", "//.*$", false, false, false),
+
+  /** The tripleslash style. */
   TRIPLESLASH_STYLE("///", "/// ", "///EOL", "", null, "///.*$", "///.*$", false, false, false),
+
+  /** The php. */
   // non generic
   PHP("/*", " * ", " */", "", "^<\\?php.*$", "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+
+  /** The asp. */
   ASP("<%", "' ", "%>", "", null, "(\\s|\\t)*<%( .*)?$", ".*%>(\\s|\\t)*$", true, true, false),
+
+  /** The lua. */
   LUA("--[[EOL", "    ", "EOL]]", "", null, "--\\[\\[$", "\\]\\]$", true, true, false),
+
+  /** The ftl. */
   FTL("<#--EOL", "    ", "EOL-->", "", null, "(\\s|\\t)*<#--.*$", ".*-->(\\s|\\t)*$", true, true, false),
+
+  /** The ftl alt. */
   FTL_ALT("[#--EOL", "    ", "EOL--]", "", "\\[#ftl(\\s.*)?\\]", "(\\s|\\t)*\\[#--.*$", ".*--\\](\\s|\\t)*$", true, true, false),
+
+  /** The text. */
   TEXT("====", "    ", "====EOL", "", null, "====.*$", "====.*$", true, true, false),
+
+  /** The batch. */
   BATCH("@REM", "@REM ", "@REMEOL", "", null, "@REM.*$", "@REM.*$", false, false, false),
+
+  /** The mustache style. */
   MUSTACHE_STYLE("{{!", "    ", "}}", "", null, "\\{\\{\\!.*$", "\\}\\}.*$", false, true, false),
+
+  /** The unknown. */
   // unknown
   UNKNOWN("", "", "", "", null, null, null, false, false, false);
 
-  ////////////////////////////////////
-
+  /** The Constant DEFINITIONS. */
   private static final Map<String, HeaderDefinition> DEFINITIONS = new HashMap<String, HeaderDefinition>(values().length);
 
   static {
@@ -78,8 +141,23 @@ public enum HeaderType {
     }
   }
 
+  /** The definition. */
   private final HeaderDefinition definition;
 
+  /**
+   * Instantiates a new header type.
+   *
+   * @param firstLine the first line
+   * @param beforeEachLine the before each line
+   * @param endLine the end line
+   * @param afterEachLine the after each line
+   * @param skipLinePattern the skip line pattern
+   * @param firstLineDetectionPattern the first line detection pattern
+   * @param lastLineDetectionPattern the last line detection pattern
+   * @param allowBlankLines the allow blank lines
+   * @param multiLine the multi line
+   * @param padLines the pad lines
+   */
   private HeaderType(String firstLine, String beforeEachLine,
                      String endLine, String afterEachLine,
                      String skipLinePattern, String firstLineDetectionPattern, String lastLineDetectionPattern,

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileContent.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileContent.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 
 import static com.mycila.maven.plugin.license.util.FileUtils.read;
 
+/**
+ * The Class FileContent.
+ */
 public final class FileContent {
   private final File file;
   private final StringBuilder fileContent;
@@ -27,6 +30,12 @@ public final class FileContent {
   private int oldPos;
   private int position;
 
+  /**
+   * Instantiates a new file content.
+   *
+   * @param file the file
+   * @param encoding the encoding
+   */
   public FileContent(File file, String encoding) {
     try {
       this.file = file;
@@ -37,24 +46,45 @@ public final class FileContent {
     }
   }
 
+  /**
+   * Reset to.
+   *
+   * @param pos the pos
+   */
   public void resetTo(int pos) {
     oldPos = position;
     position = pos;
   }
 
+  /**
+   * Reset.
+   */
   public void reset() {
     oldPos = position;
     position = 0;
   }
 
+  /**
+   * Rewind.
+   */
   public void rewind() {
     position = oldPos;
   }
 
+  /**
+   * End reached.
+   *
+   * @return true, if successful
+   */
   public boolean endReached() {
     return position >= fileContent.length();
   }
 
+  /**
+   * Next line.
+   *
+   * @return the string
+   */
   public String nextLine() {
     if (endReached()) {
       return null;
@@ -67,18 +97,38 @@ public final class FileContent {
     return str;
   }
 
+  /**
+   * Gets the position.
+   *
+   * @return the position
+   */
   public int getPosition() {
     return position;
   }
 
+  /**
+   * Delete.
+   *
+   * @param start the start
+   * @param end the end
+   */
   public void delete(int start, int end) {
     fileContent.delete(start, end);
   }
 
+  /**
+   * Insert.
+   *
+   * @param index the index
+   * @param str the str
+   */
   public void insert(int index, String str) {
     fileContent.insert(index, str);
   }
 
+  /**
+   * Removes the duplicated empty end lines.
+   */
   public void removeDuplicatedEmptyEndLines() {
     int pos;
     while ((pos = fileContent.lastIndexOf("\n")) != -1) {
@@ -100,10 +150,20 @@ public final class FileContent {
     position = fileContent.length();
   }
 
+  /**
+   * Gets the content.
+   *
+   * @return the content
+   */
   public String getContent() {
     return fileContent.toString();
   }
 
+  /**
+   * Checks if is unix.
+   *
+   * @return true, if is unix
+   */
   public boolean isUnix() {
     return unix;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileUtils.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileUtils.java
@@ -47,6 +47,14 @@ public final class FileUtils {
   private FileUtils() {
   }
 
+  /**
+   * Write.
+   *
+   * @param file the file
+   * @param content the content
+   * @param encoding the encoding
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   @SuppressWarnings("resource")
   public static void write(File file, String content, String encoding) throws IOException {
     try (FileChannel channel = new FileOutputStream(file).getChannel()) {
@@ -54,18 +62,43 @@ public final class FileUtils {
     }
   }
 
+  /**
+   * Read.
+   *
+   * @param location the location
+   * @param encoding the encoding
+   * @param properties the properties
+   * @return the string
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   public static String read(URL location, String encoding, Map<String, Object> properties) throws IOException {
     try (Reader reader = new InterpolationFilterReader(new BufferedReader(new InputStreamReader(location.openStream(), encoding)), properties)) {
       return IOUtil.toString(reader);
     }
   }
 
+  /**
+   * Read.
+   *
+   * @param location the location
+   * @param encoding the encoding
+   * @return the string
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   public static String read(URL location, String encoding) throws IOException {
     try (Reader reader = new BufferedReader(new InputStreamReader(location.openStream(), encoding))) {
       return IOUtil.toString(reader);
     }
   }
 
+  /**
+   * Read.
+   *
+   * @param locations the locations
+   * @param encoding the encoding
+   * @return the string[]
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   public static String[] read(final URL[] locations, final String encoding) throws IOException {
     final String[] results = new String[locations.length];
     for (int i = 0; i < locations.length; i++) {
@@ -76,6 +109,14 @@ public final class FileUtils {
     return results;
   }
 
+  /**
+   * Read.
+   *
+   * @param file the file
+   * @param encoding the encoding
+   * @return the string
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   @SuppressWarnings("resource")
   public static String read(File file, String encoding) throws IOException {
     try (FileChannel in = new FileInputStream(file).getChannel()) {
@@ -85,6 +126,15 @@ public final class FileUtils {
     }
   }
 
+  /**
+   * Read first lines.
+   *
+   * @param file the file
+   * @param lineCount the line count
+   * @param encoding the encoding
+   * @return the string
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   public static String readFirstLines(File file, int lineCount, String encoding) throws IOException {
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), encoding))) {
       String line;
@@ -97,6 +147,13 @@ public final class FileUtils {
     }
   }
 
+  /**
+   * Removes the.
+   *
+   * @param str the str
+   * @param chars the chars
+   * @return the string
+   */
   public static String remove(String str, String... chars) {
     for (String s : chars) {
       str = str.replace(s, "");
@@ -104,6 +161,13 @@ public final class FileUtils {
     return str;
   }
 
+  /**
+   * Copy file to folder.
+   *
+   * @param file the file
+   * @param folder the folder
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
   @SuppressWarnings("resource")
   public static void copyFileToFolder(File file, File folder) throws IOException {
     File dest = new File(folder, file.getName());
@@ -113,6 +177,12 @@ public final class FileUtils {
     }
   }
 
+  /**
+   * As path.
+   *
+   * @param file the file
+   * @return the path
+   */
   public static Path asPath(final File file) {
     if (file == null) {
       return null;
@@ -121,6 +191,12 @@ public final class FileUtils {
     return file.toPath();
   }
 
+  /**
+   * Copy files to folder.
+   *
+   * @param src the src
+   * @param dst the dst
+   */
   @SuppressWarnings({"ConstantConditions", "ResultOfMethodCallIgnored"})
   public static void copyFilesToFolder(File src, File dst) {
     dst.mkdirs();

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/Selection.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/Selection.java
@@ -42,6 +42,15 @@ public final class Selection {
 
   private DirectoryScanner scanner;
 
+  /**
+   * Instantiates a new selection.
+   *
+   * @param basedir the basedir
+   * @param included the included
+   * @param excluded the excluded
+   * @param useDefaultExcludes the use default excludes
+   * @param log the log
+   */
   public Selection(File basedir, String[] included, String[] excluded, boolean useDefaultExcludes,
                    final Log log) {
     this.basedir = basedir;
@@ -52,6 +61,11 @@ public final class Selection {
     this.excluded = buildExclusions(useDefaultExcludes, excluded, overrides);
   }
 
+  /**
+   * Gets the selected files.
+   *
+   * @return the selected files
+   */
   public String[] getSelectedFiles() {
     scanIfneeded();
     return scanner.getIncludedFiles();
@@ -62,14 +76,29 @@ public final class Selection {
     return scanner;
   }
 
+  /**
+   * Gets the basedir.
+   *
+   * @return the basedir
+   */
   public File getBasedir() {
     return basedir;
   }
 
+  /**
+   * Gets the included.
+   *
+   * @return the included
+   */
   public String[] getIncluded() {
     return included;
   }
 
+  /**
+   * Gets the excluded.
+   *
+   * @return the excluded
+   */
   public String[] getExcluded() {
     return excluded;
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/StringUtils.java
@@ -15,11 +15,20 @@
  */
 package com.mycila.maven.plugin.license.util;
 
+/**
+ * The Class StringUtils.
+ */
 public final class StringUtils {
 
   private StringUtils() {
   }
 
+  /**
+   * Rtrim.
+   *
+   * @param s the s
+   * @return the string
+   */
   public static String rtrim(java.lang.String s) {
     int i;
     for (i = s.length() - 1; i >= 0; i--) {
@@ -31,6 +40,13 @@ public final class StringUtils {
     return s.substring(0, i + 1);
   }
 
+  /**
+   * Pad right.
+   *
+   * @param s the s
+   * @param len the len
+   * @return the string
+   */
   public static String padRight(String s, int len) {
     if (s == null || s.length() >= len) {
       return s;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/CustomClassLoader.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/CustomClassLoader.java
@@ -29,10 +29,20 @@ final class CustomClassLoader extends URLClassLoader {
     super(new URL[0], parent);
   }
 
+  /**
+   * Adds the folder.
+   *
+   * @param absolutePath the absolute path
+   */
   public void addFolder(String absolutePath) {
     addFolder(new File(absolutePath));
   }
 
+  /**
+   * Adds the folder.
+   *
+   * @param folder the folder
+   */
   public void addFolder(File folder) {
     if (folder.isDirectory()) {
       try {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
@@ -26,18 +26,27 @@ import java.nio.file.Paths;
 import java.util.List;
 
 /**
- * <b>Date:</b> 26-Feb-2008<br>
- * <b>Author:</b> Mathieu Carbou (mathieu.carbou@gmail.com)
+ * The Class ResourceFinder.
  */
 public final class ResourceFinder {
   private final Path basedir;
   private CustomClassLoader compileClassPath;
   private CustomClassLoader pluginClassPath;
 
+  /**
+   * Instantiates a new resource finder.
+   *
+   * @param basedir the basedir
+   */
   public ResourceFinder(final Path basedir) {
     this.basedir = basedir;
   }
 
+  /**
+   * Sets the compile class path.
+   *
+   * @param classpath the new compile class path
+   */
   public void setCompileClassPath(List<String> classpath) {
     compileClassPath = new CustomClassLoader();
     if (classpath != null) {
@@ -47,6 +56,11 @@ public final class ResourceFinder {
     }
   }
 
+  /**
+   * Sets the plugin class path.
+   *
+   * @param classLoader the new plugin class path
+   */
   public void setPluginClassPath(ClassLoader classLoader) {
     pluginClassPath = new CustomClassLoader(classLoader);
   }


### PR DESCRIPTION
Resolves all javadoc warnings to console that are a result of failure to comply with requested setup of same.

This does not resolve one left over item where the link is being redirected to jdk 20 but makes the output of the build finally in most reasonable state.