### PR TITLE
[actions] Add drop to jdk 8 and maven 3.2.5 to run integration tests after initial build completion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
-      - name: Test with Maven
+      - name: Test with Maven Using Project Maven Wrapper
         run: ./mvnw clean install site -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      - name: Set up JDK 8 Integration Run (Consumer Run)
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: ${{ matrix.distribution }}
+      - name: Load Maven 3.2.5 Integration Run (Consumer Run) using GitHub Provided Maven
+        run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -V -B -D"maven=3.2.5"
+      - name: Test with Maven 3.2.5 Java 8 (Consumer Run)
+        run: ./mvnw invoker:run -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ nb-configuration.xml
 # OSX
 .DS_Store
 release-pom.xml
+.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
- Build will run with respective Maven in wrapper and Java designated version first.
- Using the already built binary of license plugin, build will download lowest known to work maven version 3.2.5 using mvn, not the wrapper so maven version may vary here.  This is done this way because windows won't allow wrapper to download wrapper due to jar being open.
- Finally integration tests baked into build will run against java 8 and maven 3.2.5