### PR TITLE
Dropping direct usage of jdk 8 in the ci builds and use 17 in report generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [8, 11, 17, 20, 21-ea]
+        java: [11, 17, 20, 21-ea]
         distribution: ['zulu']
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/snapshot-report.yml
+++ b/.github/workflows/snapshot-report.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '17'
           cache: 'maven'
       - name: Build with Maven
         run: ./mvnw clean install site -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
preparing to move to checkstyle requiring jdk 11.  Removing direct usage of java 8 from builds.  CI will delegate as previously merged making usage of java 8 directly unnecessary now.  The report generation will need to move simply to move and doesn't need a specific version so moved to 17.