### PR TITLE
README: Fix casing in project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LIcense Maven Plugin
+# License Maven Plugin
 
 - __Build Status:__ [![Java CI](https://github.com/mathieucarbou/license-maven-plugin/actions/workflows/ci.yaml/badge.svg)](https://github.com/mathieucarbou/license-maven-plugin/actions/workflows/ci.yaml)
 - __Issues:__ https://github.com/mathieucarbou/license-maven-plugin/issues


### PR DESCRIPTION
Fixing a small mistake in the readme. LIcense => License