### PR TITLE
[default] Ignore string template files ('st' and 'stg')

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -253,6 +253,10 @@ public final class Default {
       "**/*.ppt",
       "**/*.pptx",
 
+      // String Template
+      "**/*.st",
+      "**/*.stg",
+
       // Explicit Folder to Entirely Ignore
       "**/unlicensed/**"
   };


### PR DESCRIPTION
files are not suitable for licensing and generally skipped