### PR TITLE
[pom] Enforce byte code to java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,21 @@
   <properties>
     <!-- Get method parameter names via reflection -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <!-- Maven compiler options -->
+    <java.version>8</java.version>
+    <java.release.version>8</java.release.version>
+    <java.test.version>${java.version}</java.test.version>
+    <java.test.release.version>${java.release.version}</java.test.release.version>
+
+    <!-- Legacy compiler options source/target not really needed now (but still used by things like sonar, m2e) -->
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.testSource>${java.test.version}</maven.compiler.testSource>
+    <maven.compiler.testTarget>${java.test.version}</maven.compiler.testTarget>
+
+    <maven.compiler.release>${java.release.version}</maven.compiler.release>
+    <maven.compiler.testRelease>${java.test.release.version}</maven.compiler.testRelease>
 
     <!-- Project Encoding -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -270,6 +283,20 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.4.0</version>
+          <configuration>
+            <rules>
+              <enforceBytecodeVersion>
+                <maxJdkVersion>${java.version}</maxJdkVersion>
+              </enforceBytecodeVersion>
+            </rules>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>extra-enforcer-rules</artifactId>
+              <version>1.7.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -519,6 +546,32 @@ limitations under the License.
             <goals>
               <goal>jar</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>enforce-clean</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>pre-clean</phase>
+          </execution>
+          <execution>
+            <id>enforce-site</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>pre-site</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Main purpose here is to prevent included libraries from violating jdk requirements of project.  Currently if you set jgit to 6.6.0, it will compile without issue.  It will be caught by our usage tests on java 8, but this will further catch it right away.

Example to see, if you go to the jgit module, bump jgit to 6.6.0.202305301015-r, run a build without this, it works.  After this is added, you will get following

```
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.EnforceBytecodeVersion failed with message:
[ERROR] Found Banned Dependency: org.eclipse.jgit:org.eclipse.jgit:jar:6.6.0.202305301015-r
[ERROR] Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```

Earlier stop is more useful then waiting to make sure IT tests pass.