### PR TITLE
[pom] Move from legacy license configuration to license sets and update parent-pom to 12

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -74,12 +74,16 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/test/**</exclude>
-            <exclude>src/it/**</exclude>
-            <exclude>src/main/resources/**</exclude>
-            <exclude>**/PropertyPlaceholderResolver.java</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>src/test/**</exclude>
+                <exclude>src/it/**</exclude>
+                <exclude>src/main/resources/**</exclude>
+                <exclude>**/PropertyPlaceholderResolver.java</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.mycila</groupId>
     <artifactId>mycila-pom</artifactId>
-    <version>10</version>
+    <version>11-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -403,8 +403,10 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>4.2</version>
           <configuration>
-            <inlineHeader>
-              <![CDATA[
+            <licenseSets>
+              <licenseSet>
+                <inlineHeader>
+                  <![CDATA[
 Copyright (C) ${year} ${owner} (${email})
 
 Licensed under the Apache License, Version 2.0 (the "License").
@@ -419,18 +421,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]>
-            </inlineHeader>
-            <properties>
-              <owner>Mycila</owner>
-              <year>${project.inceptionYear}-2023</year>
-              <email>mathieu.carbou@gmail.com</email>
-            </properties>
-            <excludes>
-              <exclude>src/test/resources/**</exclude>
-              <exclude>**/release-pom.xml</exclude>
-              <exclude>docs/**</exclude>
-              <exclude>.config/**</exclude>
-            </excludes>
+                </inlineHeader>
+                <properties>
+                  <owner>Mycila</owner>
+                  <year>${project.inceptionYear}-2023</year>
+                  <email>mathieu.carbou@gmail.com</email>
+                </properties>
+                <excludes>
+                  <exclude>src/test/resources/**</exclude>
+                  <exclude>**/release-pom.xml</exclude>
+                  <exclude>docs/**</exclude>
+                  <exclude>.config/**</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.mycila</groupId>
     <artifactId>mycila-pom</artifactId>
-    <version>11-SNAPSHOT</version>
+    <version>12</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This is a draft as waiting on #623.  It can otherwise be used to test parent 11 by manually building it locally off that PR noted.