### PR TITLE
[headerType] Newline on the end for slashstar_style

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
@@ -43,7 +43,7 @@ public enum HeaderType {
   APOSTROPHE_STYLE("'", "' ", "'EOL", "", null, "'.*$", "'.*$", false, false, false),
   EXCLAMATION_STYLE("!", "! ", "!EOL", "", null, "!.*$", "!.*$", false, false, false),
   DOUBLEDASHES_STYLE("--", "-- ", "--EOL", "", null, "--.*$", "--.*$", false, false, false),
-  SLASHSTAR_STYLE("/*", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+  SLASHSTAR_STYLE("/*", " * ", " */EOL", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
   BRACESSTAR_STYLE("{*", " * ", " *}", "", null, "(\\s|\\t)*\\{\\*.*$", ".*\\*\\}(\\s|\\t)*$", false, true, false),
   SHARPSTAR_STYLE("#*", " * ", " *#", "", null, "(\\s|\\t)*#\\*.*$", ".*\\*#(\\s|\\t)*$", false, true, false),
   DOUBLETILDE_STYLE("~~", "~~ ", "~~EOL", "", null, "~~.*$", "~~.*$", false, false, false),


### PR DESCRIPTION
If you see examples in java, kotlin, etc., they mostly have newline after the copyright statement. See https://github.com/mathieucarbou/license-maven-plugin/pull/186#issuecomment-686104011 

It might be because Intellij applies header file in that way and also because in this way this would be easier to divide copyright and the code.

Since customizing the headerDefinition regarding ending newline makes a quite long configuration having to reconfigure all other values, making it default might be better ƒor this plugin to be used more common.