### PR TITLE
[docType] Add proto type

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
@@ -77,6 +77,7 @@ public enum DocumentType {
   PHP("php", HeaderType.PHP),
   POM("pom", HeaderType.XML_STYLE),
   PROPERTIES("properties", HeaderType.SCRIPT_STYLE),
+  PROTO("proto", HeaderType.DOUBLESLASH_STYLE),
   PYTHON("py", HeaderType.SCRIPT_STYLE),
   RUBY("rb", HeaderType.SCRIPT_STYLE),
   SCALA("scala", HeaderType.SLASHSTAR_STYLE),


### PR DESCRIPTION
proto files use double slash style

[example](https://github.com/tensorflow/tfx/blob/84ce53f0b2773c4592041fc548b4ca654e614b75/tfx/proto/orchestration/execution_invocation.proto)
