### PR TITLE
[documentType] Add .gradle .kts document type

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java
@@ -54,6 +54,8 @@ public enum DocumentType {
   ERLANG_HEADER("hrl", HeaderType.PERCENT3_STYLE),
   FORTRAN("f", HeaderType.EXCLAMATION_STYLE),
   FREEMARKER("ftl", HeaderType.FTL),
+  GRADLE("gradle", HeaderType.SLASHSTAR_STYLE),
+  GRADLE_KOTLIN("kts", HeaderType.SLASHSTAR_STYLE),
   GROOVY("groovy", HeaderType.SLASHSTAR_STYLE),
   GSP("GSP", HeaderType.XML_STYLE),
   H("h", HeaderType.JAVADOC_STYLE),


### PR DESCRIPTION
They use slashstar_style
[gradle](https://github.com/gradle/gradle/blob/550c50979e64b07da54803d699d036cad23f7fb9/subprojects/performance/src/templates/task-creation/build.gradle)
[kts](https://github.com/JetBrains/kotlin/blob/e9d4de658dd3110c76d7247ea639a2d00f273aef/repo/gradle-build-conventions/buildsrc-compat/src/main/kotlin/java-instrumentation.gradle.kts)

Fixes #631