### PR TITLE
[pom] Bump plexus utils to 4.0.0 and add plexus xml 3.0.0 override

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -224,7 +224,12 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
moving plexus forwards which includes some maven 4 in plexus xml so maven provided a bridge for plexus xml 3.0.0 to avoid maven 4 apis and thus remain compatible to maven 3.