### PR TITLE
chore: exclude .editorconfig file by default

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -259,7 +259,10 @@ public final class Default {
       "**/*.stg",
 
       // Explicit Folder to Entirely Ignore
-      "**/unlicensed/**"
+      "**/unlicensed/**",
+
+      // EditorConfig
+      "**/.editorconfig"
   };
 
 }


### PR DESCRIPTION
Well known editor config file recognised by most IDEs and text editors

https://editorconfig.org/