### PR TITLE
[ci] Add info when license plugin is skipped

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -491,7 +491,9 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
   @SuppressWarnings({"unchecked"})
   protected final void execute(final Callback callback) throws MojoExecutionException, MojoFailureException {
-    if (!skip) {
+    if (skip) {
+        getLog().info("License Plugin is Skipped");
+    } else {
       if (prohibitLegacyUse && detectLegacyUse()) {
         throw new MojoExecutionException("Use of legacy parameters has been prohibited by configuration.");
       }


### PR DESCRIPTION
currently plugin shows nothing, to make it clear to users, when skipped, issue message that its been skipped as most plugins do.