### PR TITLE
[docs] Fix some javadoc issues

### DIFF
--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -129,7 +129,6 @@ public class GitLookup implements Closeable {
    *                          otherwise must be {@code null}.
    * @param checkCommitsCount the number of historical commits, per file, to check
    * @param commitsToIgnore   the commits to ignore while inspecting the history for {@code anyFile}
-   * @throws IOException
    */
   private GitLookup(File anyFile, DateSource dateSource, TimeZone timeZone, int checkCommitsCount, Set<ObjectId> commitsToIgnore) {
     requireNonNull(anyFile);
@@ -192,8 +191,8 @@ public class GitLookup implements Closeable {
     return commitYear;
   }
 
-  /*
-   * Returns the year of creation for the given {@code file) based on the history of the present git branch. The
+  /**
+   * Returns the year of creation for the given {@code file} based on the history of the present git branch. The
    * year is taken either from the committer date or from the author identity depending on how {@link #dateSource} was
    * initialized.
    */

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPathResolver.java
@@ -23,9 +23,7 @@ import java.io.File;
  */
 public class GitPathResolver {
 
-  /**
-   * The path separator expected by jGit.
-   */
+  /** The path separator expected by jGit. */
   private static final char CANONICAL_PATH_SEPARATOR = '/';
 
   /**

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -180,7 +180,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
   /**
    * HeadSections define special regions of a header that allow for dynamic
-   * substitution and validation
+   * substitution and validation.
    *
    * @deprecated use {@link LicenseSet#headerSections}
    */
@@ -295,9 +295,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   @Parameter(property = "license.nThreads", defaultValue = "0")
   public int nThreads;
 
-  /**
-   * Whether to skip the plugin execution
-   */
+  /** Whether to skip the plugin execution. */
   @Parameter(property = "license.skip", defaultValue = "false")
   public boolean skip;
 
@@ -311,10 +309,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   @Parameter(property = "license.warnIfShallow", defaultValue = "true")
   public boolean warnIfShallow = true;
 
-  /**
-   * If you do not want to see the list of file having a missing header, you
-   * can add the quiet flag that will shorten the output
-   */
+  /** If you do not want to see the list of file having a missing header, you can add the quiet flag that will shorten the output. */
   @Parameter(property = "license.quiet", defaultValue = "false")
   public boolean quiet;
 
@@ -906,7 +901,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
   /**
    * Retrieves the credentials for the given server or null if none could be
-   * found
+   * found.
    *
    * @param serverID
    * @return

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/HeaderStyle.java
@@ -20,9 +20,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 public class HeaderStyle {
 
-  /**
-   * The name of this header style
-   */
+  /** The name of this header style. */
   @Parameter(required = true)
   public String name;
 
@@ -85,15 +83,11 @@ public class HeaderStyle {
   @Parameter
   public String skipLinePattern;
 
-  /**
-   * The regex used to detect the start of a header section or line
-   */
+  /** The regex used to detect the start of a header section or line. */
   @Parameter(required = true)
   public String firstLineDetectionPattern;
 
-  /**
-   * The regex used to detect the end of a header section or line
-   */
+  /** The regex used to detect the end of a header section or line. */
   @Parameter(required = true)
   public String lastLineDetectionPattern;
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 /**
- * Check if the source files of the project have a valid license header
+ * Check if the source files of the project have a valid license header.
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseFormatMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.File;
 
 /**
- * Reformat files with a missing header to add it
+ * Reformat files with a missing header to add it.
  */
 @Mojo(name = "format", threadSafe = true)
 public final class LicenseFormatMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseRemoveMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import java.io.File;
 
 /**
- * Remove the specified header from source files
+ * Remove the specified header from source files.
  */
 @Mojo(name = "remove", threadSafe = true)
 public final class LicenseRemoveMojo extends AbstractLicenseMojo {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
@@ -82,10 +82,7 @@ public class LicenseSet {
   @Parameter
   public HeaderStyle[] inlineHeaderStyles = new HeaderStyle[0];
 
-  /**
-   * HeadSections define special regions of a header that allow for dynamic
-   * substitution and validation
-   */
+  /** HeadSections define special regions of a header that allow for dynamic substitution and validation. */
   @Parameter
   public HeaderSection[] headerSections = new HeaderSection[0];
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
@@ -37,6 +37,13 @@ public interface PropertiesProvider extends Closeable {
   }
 
   /**
+   * Gets the additional properties.
+   *
+   * @param mojo              the maven mojo
+   * @param currentProperties the current properties
+   * @param document          the document to process
+   * @return the additional properties
+   *
    * @deprecated Use instead {@link #adjustProperties(AbstractLicenseMojo, Map, Document)}
    */
   @Deprecated
@@ -47,5 +54,6 @@ public interface PropertiesProvider extends Closeable {
 
   @Override
   default void close() {
+      // Do nothing on default
   }
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AbstractLicensePolicyEnforcer.java
@@ -18,7 +18,7 @@ package com.mycila.maven.plugin.license.dependencies;
 /**
  * Base class for all policy enforcer implementations.
  *
- * @param <T>
+ * @param <T> the generic license policy enforcer
  */
 public abstract class AbstractLicensePolicyEnforcer<T> implements LicensePolicyEnforcer<T> {
   private final LicensePolicy policy;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/AggregateLicensePolicyEnforcer.java
@@ -29,8 +29,8 @@ import java.util.stream.Collectors;
  * <p>
  * Rules are applied in the following order:
  * 1) defaultPolicy: unless overridden via setDefaultPolicy, this will DENY all artifacts.
- * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule.APPROVE}
- * 3) DENY policies: any policy in the Set which have {@link LIcensePolicy.Rule.DENY}
+ * 2) APPROVE policies: any policy in the Set which have {@link LicensePolicy.Rule#APPROVE}
+ * 3) DENY policies: any policy in the Set which have {@link LicensePolicy.Rule#DENY}
  */
 @SuppressWarnings("rawtypes")
 public class AggregateLicensePolicyEnforcer {
@@ -149,6 +149,7 @@ public class AggregateLicensePolicyEnforcer {
    * applying the internal set of {@link LicensePolicyEnforcer} implementations on them,
    * and returning a mapping of Artifact keys to the boolean enforcement decision made.
    *
+   * @param licenseMap the license map
    * @return final policy decision map on each artifact
    */
   public Map<Artifact, LicensePolicyEnforcerResult> apply(final LicenseMap licenseMap) {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/LicensePolicy.java
@@ -39,7 +39,7 @@ public class LicensePolicy {
     /**
      * Get a boolean form of a rule.
      *
-     * @return
+     * @return the predicate
      */
     public boolean getPredicate() {
       return allowed;

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
@@ -75,8 +75,11 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
 
   /**
    * @param session        the current {@link MavenSession}
+   * @param project        the project {@link MavenProject}
    * @param graph          the {@link DependencyGraphBuilder} implementation
    * @param projectBuilder the maven {@link ProjectBuilder} implementation
+   * @param scopes         the maven scopes
+   * @param log            the maven logger
    */
   public MavenProjectLicenses(final MavenSession session, MavenProject project, final DependencyGraphBuilder graph,
                               final ProjectBuilder projectBuilder, final List<String> scopes, final Log log) {
@@ -85,6 +88,9 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
 
   /**
    * Return a set of licenses attributed to a single artifact.
+   *
+   * @param artifact the artifact that contains the licenses
+   * @return         the licenses from artifact
    */
   protected Set<License> getLicensesFromArtifact(final Artifact artifact) {
     Set<License> licenses = new HashSet<>();

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderDefinition.java
@@ -51,6 +51,9 @@ public final class HeaderDefinition {
    *                                  if it can be outputted from the line of the file.
    * @param firstLineDetectionPattern The pattern to detect the first line of a previous header.
    * @param lastLineDetectionPattern  The pattern to detect the last line of a previous header.
+   * @param allowBlankLines           The allow blank lines flag.
+   * @param multiLine                 The multi line flag.
+   * @param padLines                  The pad lines flag.
    * @throws IllegalArgumentException If the type name is null.
    */
   public HeaderDefinition(String type,

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderParser.java
@@ -45,6 +45,7 @@ public final class HeaderParser {
    *
    * @param fileContent      The file content.
    * @param headerDefinition The associated header definition to use.
+   * @param keywords         The keywords used for finding header.
    * @throws IllegalArgumentException If the file content is null or if the header definition is null.
    */
   public HeaderParser(FileContent fileContent, HeaderDefinition headerDefinition, String[] keywords) {

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
@@ -26,8 +26,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 /**
- * <b>Date:</b> 26-Feb-2008<br>
- * <b>Author:</b> Mathieu Carbou (mathieu.carbou@gmail.com)
+ * The Class ResourceFinder.
  */
 public final class ResourceFinder {
   private final Path basedir;


### PR DESCRIPTION
This does clear the main javadoc issues.  There are some bug fixes here and only where javadoc plugin complained to fill in rest of required data on existing javadocs.  This is significantly smaller than original attempt where I had just added docs for everything.  This also does not fix the submodule doc issues but there are far less of those and they can come in later so this is kept to a minimum as needed.  Given there is one deprecated item in here, we may want to further consider removing it now but filled it out anyways.