### PR TITLE
Drop parent pom, fix up some build issues, add new discovery of .checkstyle now being produced in recent Eclipse with personal data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 
+# Checkstyle
+.checkstyle
+
 # Eclipse
 .project
 .classpath

--- a/license-maven-plugin-fs/pom.xml
+++ b/license-maven-plugin-fs/pom.xml
@@ -28,6 +28,13 @@
   <name>license-maven-plugin-fs</name>
   <description>An optional module for license-maven-plugin adding filesystem related functionality</description>
 
+  <scm>
+    <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>
+    <url>https://github.com/mathieucarbou/license-maven-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <distributionManagement>
     <site>
       <id>report</id>

--- a/license-maven-plugin-git/pom.xml
+++ b/license-maven-plugin-git/pom.xml
@@ -28,6 +28,13 @@
   <name>license-maven-plugin-git</name>
   <description>An optional module for license-maven-plugin adding git related functionality</description>
 
+  <scm>
+    <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>
+    <url>https://github.com/mathieucarbou/license-maven-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <distributionManagement>
     <site>
       <id>report</id>

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -81,6 +81,10 @@ public class GitLookup implements Closeable {
   /**
    * Lazily initializes #gitLookup assuming that all subsequent calls to this method will be related
    * to the same git repository.
+   *
+   * @param file  the file to lookup in git
+   * @param props the properties used for license plugin
+   * @return      the git lookup
    */
   public static GitLookup create(File file, Map<String, String> props) {
     final GitLookup.DateSource dateSource = Optional.ofNullable(props.get(COPYRIGHT_LAST_YEAR_SOURCE_KEY))

--- a/license-maven-plugin-svn/pom.xml
+++ b/license-maven-plugin-svn/pom.xml
@@ -26,6 +26,13 @@
   <artifactId>license-maven-plugin-svn</artifactId>
   <packaging>jar</packaging>
 
+  <scm>
+    <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>
+    <url>https://github.com/mathieucarbou/license-maven-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <distributionManagement>
     <site>
       <id>report</id>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -79,8 +79,6 @@
                 <exclude>src/it/**</exclude>
                 <exclude>src/main/resources/**</exclude>
                 <exclude>**/PropertyPlaceholderResolver.java</exclude>
-                <!-- TODO: Remove after 4.4 release -->
-                <exclude>**/*.checkstyle</exclude>
               </excludes>
             </licenseSet>
           </licenseSets>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -59,14 +59,12 @@
             <goals>
               <goal>descriptor</goal>
             </goals>
-            <phase>process-classes</phase>
           </execution>
           <execution>
             <id>help-goal</id>
             <goals>
               <goal>helpmojo</goal>
             </goals>
-            <phase>process-classes</phase>
           </execution>
         </executions>
       </plugin>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -79,6 +79,8 @@
                 <exclude>src/it/**</exclude>
                 <exclude>src/main/resources/**</exclude>
                 <exclude>**/PropertyPlaceholderResolver.java</exclude>
+                <!-- TODO: Remove after 4.4 release -->
+                <exclude>**/*.checkstyle</exclude>
               </excludes>
             </licenseSet>
           </licenseSets>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -247,6 +247,20 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Still required for MavenProjectStubs -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -248,13 +248,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>5.10.1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>5.10.1</version>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -31,12 +31,12 @@
   <name>license-maven-plugin</name>
   <description>Maven 2 plugin to check and update license headers in source files</description>
   <inceptionYear>2008</inceptionYear>
-  <url>https://oss.carbou.me/${mycila.github.name}</url>
+  <url>https://oss.carbou.me/license-maven-plugin</url>
 
   <scm>
-    <connection>scm:git:https://github.com/mathieucarbou/${mycila.github.name}.git</connection>
-    <developerConnection>scm:git:git@github.com:mycila/${mycila.github.name}.git</developerConnection>
-    <url>https://github.com/mathieucarbou/${mycila.github.name}</url>
+    <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>
+    <url>https://github.com/mathieucarbou/license-maven-plugin</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -74,7 +74,7 @@
         <configuration>
           <licenseSets>
             <licenseSet>
-              <excludes>
+              <excludes combine.children="append">
                 <exclude>src/test/**</exclude>
                 <exclude>src/it/**</exclude>
                 <exclude>src/main/resources/**</exclude>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -271,14 +271,21 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-verifier</artifactId>
-      <version>1.8.0</version>
+      <version>2.0.0-M1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -33,6 +33,9 @@ public final class Default {
       "**/.repository/**",
       "**/*.lck",
 
+      // Checkstyle
+      "**/*.checkstyle",
+
       // CVS
       "**/CVS",
       "**/CVS/**",

--- a/pom.xml
+++ b/pom.xml
@@ -112,57 +112,6 @@
       </properties>
     </developer>
   </developers>
-  <contributors>
-    <contributor>
-      <name>Peter Palaga</name>
-      <email>ppalaga@redhat.com</email>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>masakimu</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Matthieu Brouillard</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Royce Remer</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Juergen Hoeller</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Rob Harrop</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Cedric Pronzato</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Michael J. Simons</name>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </contributor>
-  </contributors>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,6 @@
           <version>${maven-plugin.version}</version>
           <configuration>
             <detail>true</detail>
-            <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           </configuration>
         </plugin>
         <plugin>
@@ -623,24 +622,6 @@ limitations under the License.
               <goal>enforce</goal>
             </goals>
             <phase>pre-site</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-helpmojo</id>
-            <goals>
-               <goal>helpmojo</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>generate-descriptor</id>
-            <goals>
-              <goal>descriptor</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/mathieucarbou/${mycila.github.name}/issues</url>
+    <url>https://github.com/mathieucarbou/license-maven-plugin/issues</url>
   </issueManagement>
 
   <ciManagement>
     <system>GitHub</system>
-    <url>https://github.com/mathieucarbou/${mycila.github.name}/actions</url>
+    <url>https://github.com/mathieucarbou/license-maven-plugin/actions</url>
   </ciManagement>
 
   <properties>
@@ -62,8 +62,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-    <mycila.github.name>license-maven-plugin</mycila.github.name>
 
     <groovy.version>4.0.16</groovy.version>
     <jacoco.minimum.coverage>1.00</jacoco.minimum.coverage>
@@ -175,9 +173,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/mathieucarbou/${mycila.github.name}.git</connection>
-    <developerConnection>scm:git:git@github.com:mycila/${mycila.github.name}.git</developerConnection>
-    <url>https://github.com/mathieucarbou/${mycila.github.name}</url>
+    <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>
+    <url>https://github.com/mathieucarbou/license-maven-plugin</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,8 @@ limitations under the License.
                   <exclude>**/release-pom.xml</exclude>
                   <exclude>docs/**</exclude>
                   <exclude>.config/**</exclude>
+                  <!-- TODO: Remove after 4.4 release -->
+                  <exclude>**/*.checkstyle</exclude>
                 </excludes>
               </licenseSet>
             </licenseSets>

--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,18 @@ limitations under the License.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,7 @@
             <notimestamp>true</notimestamp>
             <release>${java.release.version}</release>
             <source>${java.version}</source>
+            <quiet>true</quiet>
             <links>
                 <link>https://docs.oracle.com/javase/8/docs/api/</link>
             </links>

--- a/pom.xml
+++ b/pom.xml
@@ -19,21 +19,13 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>com.mycila</groupId>
-    <artifactId>mycila-pom</artifactId>
-    <version>13</version>
-    <relativePath />
-  </parent>
-
+  <groupId>com.mycila</groupId>
   <artifactId>license-maven-plugin-parent</artifactId>
   <version>4.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>license-maven-plugin-parent</name>
-  <description>Contains a Maven 2 plugin to check and update license headers in source files and its optional
-    dependencies
-  </description>
+  <description>Contains a Maven 2 plugin to check and update license headers in source files and its optional dependencies</description>
   <inceptionYear>2008</inceptionYear>
   <url>https://oss.carbou.me/license-maven-plugin/reports/${project.version}</url>
 
@@ -87,6 +79,11 @@
     <module>license-maven-plugin-svn</module>
     <module>license-maven-plugin-fs</module>
   </modules>
+
+  <organization>
+    <name>Mathieu Carbou</name>
+    <url>https://oss.carbou.me/</url>
+  </organization>
 
   <developers>
     <developer>
@@ -168,6 +165,14 @@
       </roles>
     </contributor>
   </contributors>
+
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <scm>
     <connection>scm:git:https://github.com/mathieucarbou/${mycila.github.name}.git</connection>
@@ -261,6 +266,15 @@
   </reporting>
 
   <distributionManagement>
+    <repository>
+      <id>mycila-oss-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>mycila-oss-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <uniqueVersion>false</uniqueVersion>
+    </snapshotRepository>
     <site>
       <id>report</id>
       <url>https://oss.carbou.me/license-maven-plugin/reports/${project.version}</url>
@@ -271,6 +285,11 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.3.2</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
@@ -285,6 +304,10 @@
               <enforceBytecodeVersion>
                 <maxJdkVersion>${java.version}</maxJdkVersion>
               </enforceBytecodeVersion>
+              <requireMavenVersion>
+                <version>(3.2.5,)</version>
+                <message>Require maven 3.2.5 or better.</message>
+              </requireMavenVersion>
             </rules>
           </configuration>
           <dependencies>
@@ -309,6 +332,18 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.6.3</version>
+          <configuration>
+            <additionalOptions>
+              <additionalOption>-html5</additionalOption>
+            </additionalOptions>
+            <legacyMode>true</legacyMode>
+            <notimestamp>true</notimestamp>
+            <release>${java.release.version}</release>
+            <source>${java.version}</source>
+            <links>
+                <link>https://docs.oracle.com/javase/8/docs/api/</link>
+            </links>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -377,6 +412,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>${maven-plugin.version}</version>
+          <configuration>
+            <detail>true</detail>
+            <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -439,7 +478,9 @@ limitations under the License.
           <artifactId>maven-release-plugin</artifactId>
           <version>3.0.1</version>
           <configuration>
+            <arguments>-Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
+            <releaseProfiles>release</releaseProfiles>
           </configuration>
         </plugin>
         <plugin>
@@ -454,6 +495,10 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.12.0</version>
+          <configuration>
+            <showDeprecation>true</showDeprecation>
+            <showWarnings>true</showWarnings>
+          </configuration>
           <dependencies>
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
@@ -472,20 +517,10 @@ limitations under the License.
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.11</version>
         </plugin>
-        <!--
-          fix for jacoco
-          https://stackoverflow.com/questions/76305897/maven-build-fails-after-upgrading-to-maven-source-plugin-from-3-2-1-to-3-3-0
-        -->
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-          </executions>
+          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -591,32 +626,28 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-helpmojo</id>
+            <goals>
+               <goal>helpmojo</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>generate-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
-    <profile>
-      <!-- activate release flag for Eclipse compiler compliance when in Eclipse environment -->
-      <id>m2e</id>
-      <activation>
-        <property>
-          <name>m2e.version</name>
-        </property>
-      </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
-    </profile>
-    <profile>
-      <!-- activate release flag for compiler compliance when building with JDK 9 or later -->
-      <id>jdk-release-flag</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
-    </profile>
     <profile>
       <id>report</id>
       <activation>
@@ -627,6 +658,34 @@ limitations under the License.
       <reporting>
         <outputDirectory>docs/reports/${project.version}</outputDirectory>
       </reporting>
+    </profile>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!-- Skip license plugin during release as maven release is now shallow cloned -->
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Fixes https://github.com/mathieucarbou/license-maven-plugin/issues/691

There is a lot here, normally I would have ended up splitting things up to smaller pulls but given having to run side by side comparisons with existing build in favor of dropping the parent-pom from the mix, I felt it was easier to just keep all findings together and some of that journey to get here.  You may want to also run side by side comparison to confirm.  

## Differences in the build ##
- Before, as known, source was running in both forked and non forked mode.  It now runs exactly as its supposed to and can be on latest version now.
- Maven plugin descriptor and help mojo's were running twice as the naming in parent-pom id and this project were different

## Things left behind in parent-pom ##
- Did not pull forwards any of the OSGI stuff, none of it ran against this project
- Did not pull forwards a groovydoc plugin that isn't used here either ( was in release to attach but presume it just skipped )
- Dropped some settings that were not needed, added others

## Build Review ##
Side by side of the builds was reviewed.  The internal usage of license plugin check now runs before checkstyle and the second run of enforcer is moved after those.  Only warnings left are 'our' deprecation(s) and usage of deprecated maven features.

## Checkstyle ##
Newly discovered with Eclipse 2023-12 checkstyle integration is that its creating .checkstyle files.  I don't know if those files are new but had not seen that before and they started showing up in last week or so which I had been ignoring.  I've added a temporary ignore in our build for internal check and added this to general ignore defaults.  It does have disk identifying data in it so ignoring it makes most sense as unlikely checked in items.

## Follow-ups ##
As a follow up on javadoc issue, fixed the last remaining alerted warning.

As a fix to internal license, made sure the excludes is inherited, this was noticed when .checkstyle was added in parent but then ignored in the plugin module.

## Junit 5 ##
I also noticed junit 5 vintage usage and tried to remove that but its still needed somehow by maven plugin even though we updated to their junit 5 copy.  They do have it noted as optional and its failing with junit 3 classes being missing which we are not using and I could only find in one test case of mavens so not exactly sure where they are pulling that as the stack trace seemed to indicate that project causes it.  When adding vintage back though, I did some work on hamcrest as the 'core' module is empty and long deprecated to use the main one (all code was merged into single module).  So that is cleaned up so we don't have both hamcrest and hamcrest-core floating around.  I did note where exactly this vintage usage is needed.  If that is fixed in some future release of maven testing harness which I'd suspect would be, we would still need hamcrest as we are using it at the moment.