### PR TITLE
[cleanup] Remove internally deprecated default class not used

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/PropertiesProvider.java
@@ -20,35 +20,18 @@ import com.mycila.maven.plugin.license.document.Document;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  */
 public interface PropertiesProvider extends Closeable {
 
   default void init(AbstractLicenseMojo mojo, Map<String, String> currentProperties) {
+      // Do nothing on default
   }
 
   default Map<String, String> adjustProperties(AbstractLicenseMojo mojo,
                                                Map<String, String> currentProperties, Document document) {
-    Properties properties = new Properties();
-    properties.putAll(currentProperties);
-    return getAdditionalProperties(mojo, properties, document);
-  }
-
-  /**
-   * Gets the additional properties.
-   *
-   * @param mojo              the maven mojo
-   * @param currentProperties the current properties
-   * @param document          the document to process
-   * @return the additional properties
-   *
-   * @deprecated Use instead {@link #adjustProperties(AbstractLicenseMojo, Map, Document)}
-   */
-  @Deprecated
-  default Map<String, String> getAdditionalProperties(AbstractLicenseMojo mojo,
-                                                      Properties currentProperties, Document document) {
+    // Return empty collection on default
     return Collections.emptyMap();
   }
 


### PR DESCRIPTION
All this does is waste memory on the license-maven-plugin-fs test that uses it.  Everything else uses defined properties via providers.  There is no instance that a missing provider would have even had this data in fact used.  So its unnecessary.

The adjustProperties fails to use what it created there so that just goes to GC.

The deprecated method only returns Collections.emptyMap().

Due to test in the license-maven-plugin-fs, keep these as default but have them do nothing as that is what they are actually doing.  The adjustProperties will remain to send back emptyMap().

The close() is in fact used earlier on in main code in that it removes the IOException as none exist in all its use-cases which makes the functional usage not have to deal with non thrown exception.

Net result, no real change.  Build is effectively the same, code usage would be same, the removed deprecated item isn't used in the code base and was not public to the maven plugin in that context.