### PR TITLE
Require maven 3.6.3 along with GHA updates to get mac running java 8 again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,6 @@ jobs:
           java-version: 8
           distribution: ${{ matrix.distribution }}
       - name: Load Maven 3.2.5 Integration Run (Consumer Run) using GitHub Provided Maven
-        run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper -V -B -D"maven=3.2.5"
+        run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper -V -B -D"maven=3.2.5"
       - name: Test with Maven 3.2.5 Java 8 (Consumer Run)
         run: ./mvnw invoker:run -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           java-version: 8
           distribution: ${{ matrix.distribution }}
-      - name: Load Maven 3.2.5 Integration Run (Consumer Run) using GitHub Provided Maven
-        run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper -V -B -D"maven=3.2.5"
-      - name: Test with Maven 3.2.5 Java 8 (Consumer Run)
+      - name: Load Maven 3.6.3 Integration Run (Consumer Run) using GitHub Provided Maven
+        run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper -V -B -D"maven=3.6.3"
+      - name: Test with Maven 3.6.3 Java 8 (Consumer Run)
         run: ./mvnw invoker:run -V -B -D"maven.artifact.threads=64" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: ${{ matrix.distribution }}
+          distribution: ${{ runner.os == 'macOS' && 'zulu' || 'temurin' }}
       - name: Load Maven 3.6.3 Integration Run (Consumer Run) using GitHub Provided Maven
         run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper -V -B -D"maven=3.6.3"
       - name: Test with Maven 3.6.3 Java 8 (Consumer Run)

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -33,6 +33,10 @@
   <inceptionYear>2008</inceptionYear>
   <url>https://oss.carbou.me/license-maven-plugin</url>
 
+  <prerequisites>
+    <maven>3.6.3</maven>
+  </prerequisites>
+
   <scm>
     <connection>scm:git:https://github.com/mathieucarbou/license-maven-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:mycila/license-maven-plugin.git</developerConnection>


### PR DESCRIPTION
See https://maven.apache.org/docs/history.html for maven support requires.