### PR TITLE
[exclusions] Do not handle .gradle or build directories

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -118,6 +118,10 @@ public final class Default {
       "**/pom.xml.releaseBackup",
       "**/pom.xml.versionsBackup",
 
+      // gradle files
+      "**/.gradle/**",
+      "**/build/**",
+
       // Node
       "**/node/**",
       "**/node_modules/**",


### PR DESCRIPTION
those are auto generated and should not be considered.  some projects use both maven and gradle so this conflicts, so ignore it like we do gradle wrapper.

c