### PR TITLE
feat: Add a property to limit plugin to a list of files

### DIFF
--- a/license-maven-plugin/src/it/legacy-config-checkFiles/invoker.properties
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=license:format

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/mock-license.txt
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/mock-license.txt
@@ -1,0 +1,2 @@
+This is a
+mock license

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/pom.xml
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycila.license-maven-plugin.it</groupId>
+  <artifactId>legacy-config</artifactId>
+  <version>1.0.0</version>
+
+  <name>Check Legacy Configuration with checkFiles</name>
+  <description>Integration Test for checking legacy configuration with checkFiles</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <header>mock-license.txt</header>
+          <excludes>
+            <exclude>invoker.properties</exclude>
+            <exclude>pom.xml</exclude>
+            <exclude>*.groovy</exclude>
+            <exclude>**/*.bak</exclude>
+            <exclude>*.log</exclude>
+          </excludes>
+          <filesToCheck>src/main/java/com/mycilla/it/Unformatted2.java</filesToCheck>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/setup.groovy
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/setup.groovy
@@ -1,0 +1,23 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+  System.err.println("base directory is missing.")
+  return false
+}
+
+final List<String> ALL_FILES = Arrays.asList("Unformatted1.java", "Unformatted2.java")
+
+for (final String filename : ALL_FILES) {
+  final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+  if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(filename + " file is missing.")
+    return false
+  }
+
+  Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling(filename + ".bak"))
+}
+
+return true;

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/src/main/java/com/mycilla/it/Unformatted2.java
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/src/main/java/com/mycilla/it/Unformatted2.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted2 {
+}

--- a/license-maven-plugin/src/it/legacy-config-checkFiles/verify.groovy
+++ b/license-maven-plugin/src/it/legacy-config-checkFiles/verify.groovy
@@ -1,0 +1,61 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+  System.err.println("base directory is missing.")
+  return false
+}
+
+final Path license = base.resolve("mock-license.txt")
+if (!Files.exists(license)) {
+  System.err.println("license file is missing.")
+  return false
+}
+
+final Path unformattedJavaFile1 = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java.bak")
+if (!Files.exists(unformattedJavaFile1)) {
+  System.err.println(unformattedJavaFile1.getFileName() + " file is missing (should have been created by setup.groovy).")
+  return false
+}
+
+final Path unformattedJavaFile2 = base.resolve("src/main/java/com/mycilla/it/Unformatted2.java.bak")
+if (!Files.exists(unformattedJavaFile2)) {
+  System.err.println(unformattedJavaFile2.getFileName() + " file is missing (should have been created by setup.groovy).")
+  return false
+}
+
+final Path formattedJavaFile1 = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(formattedJavaFile1)) {
+  System.err.println(formattedJavaFile1.getFileName() + " file is missing.")
+  return false
+}
+
+
+final Path formattedJavaFile2 = base.resolve("src/main/java/com/mycilla/it/Unformatted2.java")
+if (!Files.exists(formattedJavaFile2)) {
+  System.err.println(formattedJavaFile2.getFileName() + " file is missing.")
+  return false
+}
+
+assertEquals(new String(Files.readAllBytes(formattedJavaFile1)), new String(Files.readAllBytes(unformattedJavaFile1)))
+
+final StringBuilder expected = new StringBuilder();
+expected.append("/*\n");
+license.withReader { reader ->
+  while ((line = reader.readLine()) != null) {
+    expected.append(" * ").append(line).append('\n')
+  }
+}
+expected.append(" */\n")
+expected.append(new String(Files.readAllBytes(unformattedJavaFile2)))
+
+final String actual = new String(Files.readAllBytes(formattedJavaFile2))
+
+assertEquals(expected.toString(), actual)
+
+return true

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/invoker.properties
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=license:format

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-1.txt
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-1.txt
@@ -1,0 +1,2 @@
+This is the 1st
+mock license

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-2.txt
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-2.txt
@@ -1,0 +1,2 @@
+This is the 2nd
+mock license

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-3.txt
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/mock-license-3.txt
@@ -1,0 +1,2 @@
+This is the 3rd
+mock license

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/pom.xml
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycila.license-maven-plugin.it</groupId>
+  <artifactId>tri-license-set</artifactId>
+  <version>1.0.0</version>
+
+  <name>Check a Triple License Set</name>
+  <description>Integration Test for checking a triple license set</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <filesToCheck>src/main/java/com/mycilla/it/Unformatted2.java</filesToCheck>
+          <licenseSets>
+            <licenseSet>
+              <header>mock-license-1.txt</header>
+              <excludes>
+                <exclude>invoker.properties</exclude>
+                <exclude>pom.xml</exclude>
+                <exclude>*.groovy</exclude>
+                <exclude>**/*.bak</exclude>
+                <exclude>*.log</exclude>
+                <exclude>mock-license-*</exclude>
+                <exclude>**/Unformatted2.java</exclude>
+                <exclude>**/Unformatted3.java</exclude>
+              </excludes>
+            </licenseSet>
+            <licenseSet>
+              <header>mock-license-2.txt</header>
+              <excludes>
+                <exclude>invoker.properties</exclude>
+                <exclude>pom.xml</exclude>
+                <exclude>*.groovy</exclude>
+                <exclude>**/*.bak</exclude>
+                <exclude>*.log</exclude>
+                <exclude>mock-license-*</exclude>
+                <exclude>**/Unformatted1.java</exclude>
+                <exclude>**/Unformatted3.java</exclude>
+              </excludes>
+            </licenseSet>
+            <licenseSet>
+              <header>mock-license-3.txt</header>
+              <includes>
+                <include>**/Unformatted3.java</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/setup.groovy
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/setup.groovy
@@ -1,0 +1,23 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+  System.err.println("base directory is missing.")
+  return false
+}
+
+final List<String> ALL_FILES = Arrays.asList("Unformatted1.java", "Unformatted2.java", "Unformatted3.java")
+
+for (final String filename : ALL_FILES) {
+  final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+  if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(filename + " file is missing.")
+    return false
+  }
+
+  Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling(filename + ".bak"))
+}
+
+return true;

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted2.java
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted2.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted2 {
+}

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted3.java
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/src/main/java/com/mycilla/it/Unformatted3.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted3 {
+}

--- a/license-maven-plugin/src/it/tri-license-set-checkFiles/verify.groovy
+++ b/license-maven-plugin/src/it/tri-license-set-checkFiles/verify.groovy
@@ -1,0 +1,53 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+  System.err.println("base directory is missing.")
+  return false
+}
+
+for (int i = 1; i <= 3; i++) {
+
+  final Path license = base.resolve("mock-license-" + i + ".txt")
+  if (!Files.exists(license)) {
+    System.err.println(license.getFileName() + " file is missing.")
+    return false
+  }
+
+  final String filename = "Unformatted" + i + ".java"
+
+  final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename + ".bak")
+  if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+    return false
+  }
+
+  final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+  if (!Files.exists(formattedJavaFile)) {
+    System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+    return false
+  }
+
+  final StringBuilder expected = new StringBuilder();
+  if (i == 2) {
+    expected.append("/*\n");
+    license.withReader { reader ->
+      while ((line = reader.readLine()) != null) {
+        expected.append(" * ").append(line).append('\n')
+      }
+    }
+    expected.append(" */\n")
+  }
+  expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+  final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+  assertEquals(expected.toString(), actual)
+}
+
+return true

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -200,6 +200,15 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   public Map<String, String> defaultProperties = new HashMap<>();
 
   /**
+   * Specifies files, which files are to check. By default, all files
+   * are included.
+   *
+   */
+  @Parameter(alias = "filesToCheck", property = "license.filesToCheck")
+  public String[] filesToCheck = new String[0];
+
+
+  /**
    * Specifies files, which are included in the check. By default, all files
    * are included.
    *
@@ -786,14 +795,22 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
   }
 
   private String[] listSelectedFiles(final LicenseSet licenseSet) {
-    final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes : defaultUseDefaultExcludes);
-    final Selection selection = new Selection(
-        firstNonNull(licenseSet.basedir, defaultBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes,
-        getLog());
-    debug("From: %s", firstNonNull(licenseSet.basedir, defaultBasedir));
-    debug("Including: %s", deepToString(selection.getIncluded()));
-    debug("Excluding: %s", deepToString(selection.getExcluded()));
-    return selection.getSelectedFiles();
+    final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes
+        : defaultUseDefaultExcludes);
+    if (filesToCheck == null || filesToCheck.length == 0) {
+      final Selection selection = new Selection(firstNonNull(licenseSet.basedir, defaultBasedir), licenseSet.includes, buildExcludes(licenseSet),
+          useDefaultExcludes, getLog());
+      debug("From: %s", firstNonNull(licenseSet.basedir, defaultBasedir));
+      debug("Including: %s", deepToString(selection.getIncluded()));
+      debug("Excluding: %s", deepToString(selection.getExcluded()));
+      return selection.getSelectedFiles();
+    } else {
+      final Selection selection = new Selection(filesToCheck, licenseSet.includes, buildExcludes(licenseSet),
+          useDefaultExcludes, getLog());
+      debug("Including: %s", deepToString(selection.getIncluded()));
+      debug("Excluding: %s", deepToString(selection.getExcluded()));
+      return selection.getSelectedFiles();
+    }
   }
 
   private String[] buildExcludes(final LicenseSet licenseSet) {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
@@ -57,7 +57,7 @@ class ReportTest {
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
     plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.legacyConfigIncludes = new String[] { "file*.*" };
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.xml");
 
     try {
@@ -67,9 +67,35 @@ class ReportTest {
     }
 
     String processed = unixify(FileUtils.read(plugin.reportLocation, Charset.defaultCharset()));
-    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/check.xml"), Charset.defaultCharset());
+    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/check.xml"),
+        Charset.defaultCharset());
     assertThat(processed, is(equalTo(expected)));
   }
+
+  @Test
+  void test_check_xml_with_checkFiles() throws Exception {
+    File tmp = new File("target/test/issues/issue-122/test_check_xml_with_checkFiles");
+    FileUtils.copyFilesToFolder(new File("src/test/resources/issues/issue-122"), tmp);
+
+    AbstractLicenseMojo plugin = new LicenseCheckMojo();
+    plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
+    plugin.project = mavenProjectStub;
+    plugin.defaultBasedir = tmp;
+    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
+    plugin.filesToCheck = new String[]{"file2.mv"};
+    plugin.reportLocation = new File(tmp, "report/license-plugin-report.xml");
+
+    try {
+      plugin.execute();
+      Assertions.fail();
+    } catch (MojoExecutionException | MojoFailureException e) {
+    }
+
+    String processed = unixify(FileUtils.read(plugin.reportLocation, Charset.defaultCharset()));
+    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/check_checkFiles.xml"), Charset.defaultCharset());
+    assertThat(processed, is(equalTo(expected)));
+  }
+
 
   @Test
   void test_check_json() throws Exception {
@@ -94,6 +120,31 @@ class ReportTest {
     String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/check.json"), Charset.defaultCharset());
     assertThat(processed, is(equalTo(expected)));
   }
+
+  @Test
+  void test_check_json_with_checkFiles() throws Exception {
+    File tmp = new File("target/test/issues/issue-122/test_check_json_with_checkFiles");
+    FileUtils.copyFilesToFolder(new File("src/test/resources/issues/issue-122"), tmp);
+
+    AbstractLicenseMojo plugin = new LicenseCheckMojo();
+    plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
+    plugin.project = mavenProjectStub;
+    plugin.defaultBasedir = tmp;
+    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
+    plugin.filesToCheck = new String[]{"file2.mv"};
+    plugin.reportLocation = new File(tmp, "report/license-plugin-report.json");
+
+    try {
+      plugin.execute();
+      Assertions.fail();
+    } catch (MojoExecutionException | MojoFailureException e) {
+    }
+
+    String processed = unixify(FileUtils.read(plugin.reportLocation, Charset.defaultCharset()));
+    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/check_checkFiles.json"), Charset.defaultCharset());
+    assertThat(processed, is(equalTo(expected)));
+  }
+
 
   @Test
   void test_format_xml() throws Exception {
@@ -165,13 +216,14 @@ class ReportTest {
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
     plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.legacyConfigIncludes = new String[] { "file*.*" };
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.json");
 
     plugin.execute();
 
     String processed = unixify(FileUtils.read(plugin.reportLocation, Charset.defaultCharset()));
-    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/remove.json"), Charset.defaultCharset());
+    String expected = FileUtils.read(new File("src/test/resources/issues/issue-122/remove.json"),
+        Charset.defaultCharset());
     assertThat(processed, is(equalTo(expected)));
   }
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
@@ -134,4 +134,26 @@ class SelectionTest {
     }
     log.debug("Created '" + newFile.getAbsolutePath() + "'");
   }
+
+  @Test
+  void test_exclusions_respect_with_files_to_check() throws IOException {
+    SystemStreamLog log = new SystemStreamLog() {
+      @Override
+      public boolean isDebugEnabled() {
+        return true;
+      }
+    };
+    File root = createAFakeProject(log);
+    Selection selection = new Selection(
+        new String[] {"module/target/ignored.txt", "module/src/main/java/not-ignored.txt"},
+        new String[]{"**" + File.separator + "*.txt"},
+        new String[]{"target" + File.separator + "**", "module" + File.separator + "**" + File.separator + "target" + File.separator + "**"}, false,
+        log);
+
+    String[] selectedFiles = selection.getSelectedFiles(); // triggers scan and scanner build
+    org.assertj.core.api.Assertions.assertThat(selectedFiles)
+        .hasSize(1)
+        .allMatch(f -> f.equals("module/src/main/java/not-ignored.txt"));
+  }
+
 }

--- a/license-maven-plugin/src/test/resources/issues/issue-122/check_checkFiles.json
+++ b/license-maven-plugin/src/test/resources/issues/issue-122/check_checkFiles.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": "1631615047644",
+  "goal": "CHECK",
+  "module": {
+    "groupId": "com.mycila",
+    "artifactId": "license-maven-plugin",
+    "version": "4.2-SNAPSHOT"
+  },
+  "files": [
+    {
+      "path": "target/test/issues/issue-122/test_check_json_with_checkFiles/file2.mv",
+      "result": "MISSING"
+    }
+  ]
+}

--- a/license-maven-plugin/src/test/resources/issues/issue-122/check_checkFiles.xml
+++ b/license-maven-plugin/src/test/resources/issues/issue-122/check_checkFiles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<licensePluginReport goal="CHECK" timestamp="1631615047644">
+    <module artifactId="license-maven-plugin" groupId="com.mycila" version="4.2-SNAPSHOT"/>
+    <files>
+        <file path="target/test/issues/issue-122/test_check_xml_with_checkFiles/file2.mv" result="MISSING"/>
+    </files>
+</licensePluginReport>


### PR DESCRIPTION
The idea is to be able to use this plugin from a pre-commit hook (only run on a set of files)

usage: mvn license:check -Dlicense.filesToCheck="src/main/org/acme/MyClass.java,src/main/org/acme/MyEnum.java"

ref #536 