### PR TITLE
[java11] Use Path.of instead of Paths.get

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -46,7 +45,7 @@ public final class MavenWrapperDownloader {
             log(" - Downloader started");
             final URL wrapperUrl = URI.create(args[0]).toURL();
             final String jarPath = args[1].replace("..", ""); // Sanitize path
-            final Path wrapperJarPath = Paths.get(jarPath).toAbsolutePath().normalize();
+            final Path wrapperJarPath = Path.of(jarPath).toAbsolutePath().normalize();
             downloadFileFromURL(wrapperUrl, wrapperJarPath);
             log("Done");
         } catch (IOException e) {

--- a/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-fs/src/test/java/com/mycila/maven/plugin/license/fs/CopyrightRangeProviderTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.HashMap;
@@ -78,14 +77,14 @@ class CopyrightRangeProviderTest {
   }
 
   private static Document newDocument(String relativePath) {
-    Path path = Paths.get(fsRepoRoot + File.separator
+    Path path = Path.of(fsRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar));
     return new Document(path.toFile(), null, StandardCharsets.UTF_8, new String[0], null);
   }
 
   @BeforeAll
   static void beforeClass() throws IOException {
-    fsRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "fs-test-repo");
+    fsRepoRoot = Path.of(tempFolder.toPath() + File.separator + "fs-test-repo");
 
     Files.createDirectories(fsRepoRoot.resolve("dir1"));
     Files.createFile(fsRepoRoot.resolve("dir1/file1.txt"));

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,7 +61,7 @@ class CopyrightAuthorProviderTest {
   }
 
   private static Document newDocument(String relativePath) {
-    Path path = Paths.get(gitRepoRoot + File.separator
+    Path path = Path.of(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar));
     return new Document(path.toFile(), null, StandardCharsets.UTF_8, new String[0], null);
   }
@@ -70,7 +69,7 @@ class CopyrightAuthorProviderTest {
   @BeforeAll
   static void beforeClass() throws IOException {
     URL url = CopyrightAuthorProviderTest.class.getResource("git-test-repo.zip");
-    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
+    gitRepoRoot = Path.of(tempFolder.toPath() + File.separator + "git-test-repo");
 
     GitLookupTest.unzip(url, tempFolder.toPath());
   }

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -84,7 +83,7 @@ class CopyrightRangeProviderTest {
   }
 
   private static Document newDocument(String relativePath) {
-    Path path = Paths.get(gitRepoRoot + File.separator
+    Path path = Path.of(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar));
     return new Document(path.toFile(), null, StandardCharsets.UTF_8, new String[0], null);
   }
@@ -92,7 +91,7 @@ class CopyrightRangeProviderTest {
   @BeforeAll
   static void beforeClass() throws IOException {
     URL url = CopyrightAuthorProviderTest.class.getResource("git-test-repo.zip");
-    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
+    gitRepoRoot = Path.of(tempFolder.toPath() + File.separator + "git-test-repo");
 
     GitLookupTest.unzip(url, tempFolder.toPath());
   }

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +47,7 @@ class GitLookupTest {
   @BeforeAll
   static void beforeClass() throws IOException {
     URL url = GitLookupTest.class.getResource("git-test-repo.zip");
-    gitRepoRoot = Paths.get(tempFolder.toPath() + File.separator + "git-test-repo");
+    gitRepoRoot = Path.of(tempFolder.toPath() + File.separator + "git-test-repo");
     unzip(url, tempFolder.toPath());
   }
 
@@ -59,7 +58,7 @@ class GitLookupTest {
       while ((entry = zipInputStream.getNextEntry()) != null) {
 
         String fileName = entry.getName();
-        Path unzippedFile = Paths.get(unzipDestination.toAbsolutePath() + File.separator + fileName);
+        Path unzippedFile = Path.of(unzipDestination.toAbsolutePath() + File.separator + fileName);
         if (entry.isDirectory()) {
           unzippedFile.toFile().mkdirs();
         } else {
@@ -252,14 +251,14 @@ class GitLookupTest {
 
   private void assertLastChange(GitLookup provider, String relativePath, int expected) throws
       GitAPIException, IOException {
-    int actual = provider.getYearOfLastChange(Paths.get(gitRepoRoot + File.separator
+    int actual = provider.getYearOfLastChange(Path.of(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar)).toFile());
     Assertions.assertEquals(expected, actual);
   }
 
   private void assertCreation(GitLookup provider, String relativePath, int expected) throws
       GitAPIException, IOException {
-    int actual = provider.getYearOfCreation(Paths.get(gitRepoRoot + File.separator
+    int actual = provider.getYearOfCreation(Path.of(gitRepoRoot + File.separator
         + relativePath.replace('/', File.separatorChar)).toFile());
     Assertions.assertEquals(expected, actual);
   }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/resource/ResourceFinder.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -78,9 +77,9 @@ public final class ResourceFinder {
 
     // if not found, search for absolute location on file system, or relative to execution dir
     try {
-      res = toURL(Paths.get(resource));
+      res = toURL(Path.of(resource));
     } catch (final InvalidPathException e) {
-      // no-op - can be caused by resource being a URI on windows when Paths.get is called
+      // no-op - can be caused by resource being a URI on windows when Path.of is called
     }
     if (res != null) {
       return res;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderSourceTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderSourceTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import static com.mycila.maven.plugin.license.Multi.DEFAULT_SEPARATOR;
 
 class HeaderSourceTest {
 
-  private ResourceFinder finder = new ResourceFinder(Paths.get("src", "test", "resources"));
+  private ResourceFinder finder = new ResourceFinder(Path.of("src", "test", "resources"));
 
   @Test
   void testOfInline() {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/resource/ResourceFinderTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/resource/ResourceFinderTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 
 class ResourceFinderTest {
@@ -32,17 +31,17 @@ class ResourceFinderTest {
 
   @BeforeAll
   static void setup() {
-    finder = new ResourceFinder(Paths.get("."));
+    finder = new ResourceFinder(Path.of("."));
     finder.setCompileClassPath(Arrays.asList("src/test/data/compileCP"));
     finder.setPluginClassPath(ResourceFinderTest.class.getClassLoader());
   }
 
   @Test
   void test_load_absolute_file() throws Exception {
-    final Path path = Paths.get("src").resolve("test/data/compileCP/test.txt").toAbsolutePath();
+    final Path path = Path.of("src").resolve("test/data/compileCP/test.txt").toAbsolutePath();
     Assertions.assertTrue(Files.exists(path));
     final URL u = finder.findResource(path.toString());
-    Assertions.assertEquals(path, Paths.get(u.toURI()));
+    Assertions.assertEquals(path, Path.of(u.toURI()));
   }
 
   @Test
@@ -71,7 +70,7 @@ class ResourceFinderTest {
 
   @Test
   void test_load_from_URL() throws Exception {
-    final Path path = Paths.get("src").resolve("test/data/compileCP/test.txt").toAbsolutePath();
+    final Path path = Path.of("src").resolve("test/data/compileCP/test.txt").toAbsolutePath();
     Assertions.assertTrue(Files.exists(path));
     final String url = path.toUri().toURL().toString();
     Assertions.assertNotNull(finder.findResource(url));


### PR DESCRIPTION
after java 11, Paths.get is just calling Path.of

See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#of(java.lang.String,java.lang.String...)