### PR TITLE
Build cleanup items

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 21, 22]
+        java: [11, 17, 21, 23, 24-ea, 25-ea]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 21, 23, 24-ea, 25-ea]
+        java: [11, 17, 21, 23, 24-ea]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -176,6 +176,18 @@
     </site>
   </distributionManagement>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>5.15.2</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
             <rules>
               <enforceBytecodeVersion>
                 <maxJdkVersion>${java.version}</maxJdkVersion>
+                <ignoredScopes>test</ignoredScopes>
               </enforceBytecodeVersion>
               <requireMavenVersion>
                 <version>(3.6.3,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
             <rules>
               <enforceBytecodeVersion>
                 <maxJdkVersion>${java.version}</maxJdkVersion>
-                <ignoredScopes>test</ignoredScopes>
+                <ignoredScopes>provided,test</ignoredScopes>
               </enforceBytecodeVersion>
               <requireMavenVersion>
                 <version>(3.6.3,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
             <source>${java.version}</source>
             <quiet>true</quiet>
             <links>
-                <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
             </links>
           </configuration>
         </plugin>


### PR DESCRIPTION
- Added mockito bom to ensure its usage of byte buddy doesn't get manipulated by another other libs so higher jdks work without issues.
- Drop jdk 22 on build matrix
- Add jdk 23 on build matrix
- Add jdk 24-ea on build matrix
- Do not care about byte compatibility for 'test' or 'provided' scope as neither affects consumers
- Fix javadoc link to java 11 fixing jdk 23+