### PR TITLE
Add to default exclusion and cleanup pom on exclusions already in core releases

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -114,9 +114,11 @@ public final class Default {
       "**/test-output/**",
       "**/release.properties",
       "**/dependency-reduced-pom.xml",
-      "**/release-pom.xml",
+      "**/pom.xml.tag",
       "**/pom.xml.releaseBackup",
       "**/pom.xml.versionsBackup",
+      "**/pom.xml.next",
+      "**/release-pom.xml",
 
       // angular files
       "**/.angular/**",

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -150,6 +150,9 @@ public final class Default {
       // Netbeans
       "**/nb-configuration.xml",
 
+      // VSCode
+      "**/.vscode/**",
+
       // Hibernate Validator Annotation Processor
       "**/.factorypath",
 

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,6 @@ limitations under the License.
                 </properties>
                 <excludes>
                   <exclude>src/test/resources/**</exclude>
-                  <exclude>**/release-pom.xml</exclude>
                   <exclude>docs/**</exclude>
                   <exclude>.config/**</exclude>
                   <!-- TODO: Remove after 5.0.0 release -->

--- a/pom.xml
+++ b/pom.xml
@@ -419,8 +419,7 @@ limitations under the License.
                   <exclude>**/release-pom.xml</exclude>
                   <exclude>docs/**</exclude>
                   <exclude>.config/**</exclude>
-                  <!-- TODO: Remove after 4.4 release -->
-                  <exclude>**/*.checkstyle</exclude>
+                  <!-- TODO: Remove after 5.0.0 release -->
                   <exclude>.vscode/**</exclude>
                 </excludes>
               </licenseSet>


### PR DESCRIPTION
- Sorted section including pom.xml items, added tag and next entries
- Add .vscode to ignores
- Removed from internal license plugin exclusions .checkstyle and release-pom.xml as already ignored.