### PR TITLE
[gha] Make sure we cache maven (and sort) and make sure docs are proper EOF marked

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,9 @@ jobs:
       - name: Set up JDK 11 Integration Run (Consumer Run)
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          cache: 'maven'
           distribution: ${{ runner.os == 'macOS' && 'zulu' || 'temurin' }}
+          java-version: 11
       - name: Load Maven 3.6.3 Integration Run (Consumer Run) using GitHub Provided Maven
         run: mvn org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper -V -B -D"maven=3.6.3"
       - name: Test with Maven 3.6.3 Java 11 (Consumer Run)

--- a/.github/workflows/snapshot-report.yml
+++ b/.github/workflows/snapshot-report.yml
@@ -15,11 +15,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
+          cache: 'maven'
           distribution: 'zulu'
           java-version: '21'
-          cache: 'maven'
       - name: Build with Maven
         run: ./mvnw clean install site -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      - name: Fix eol markers
+        run: cd docs && git grep --null --files-with-matches -I '' | while IFS= read -rd '' f; do tail -c1 < "$f" | read -r _ || echo >> "$f"; done
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
Git expects all readable files have proper end of file line marker to assist with diffs.

Some info on this is here https://stackoverflow.com/questions/5813311/whats-the-significance-of-the-no-newline-at-end-of-file-log.

The largest contributor to this problem on the repo right now is the docs folder.

In order to properly fix files we really care about, we need to ensure the docs that are integrated into the overall build files adhere to this standard.

Note: This was not tested on GHA but is a command used locally by me for number of years.  It may need a bit of tweaking in case expected syntax is off a bit on translation from git alias to a call on github.  Not sure the best way to test this otherwise then see if it works.  I've otherwise ran the command from a git alias locally and just about every file in docs is affected.  Then outside of that we have a much smaller set that need to be resolved which will be done separately in a single commit.  Most repos I've worked on, most contributors generally have the files right but if we are ever concerned they are not or want to ensure we don't have this issue post this point, we can simply add a separate plugin git-build-hook-maven-plugin which can do this as a pre commit action when committing the code.  We would still want docs handled as the files look to be generated in very flat way (possibly from the site call) and this will ensure they are ok.  Its unusual to me at least to have very fluid docs from site generated embedded to the direct main instead of using gh-pages.  So this is very unique need that would normally be ignored.  Expectation here is this will be ugly the first time, then stabilize afterwards.