### PR TITLE
Use less of plexus and no longer need to override plexus xml

### DIFF
--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -228,11 +228,6 @@
       <artifactId>plexus-utils</artifactId>
       <version>4.0.2</version>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-xml</artifactId>
-      <version>3.0.1</version>
-    </dependency>
 
     <dependency>
       <groupId>com.mycila</groupId>

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
@@ -16,10 +16,10 @@
 package com.mycila.maven.plugin.license.document;
 
 import com.mycila.maven.plugin.license.header.HeaderDefinition;
-import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.Map;
 
 public final class DocumentFactory {
@@ -45,7 +45,7 @@ public final class DocumentFactory {
 
   private Document getWrapper(final String file) {
     String headerType = mapping.get("");
-    String lowerFileName = FileUtils.filename(file).toLowerCase();
+    String lowerFileName = Path.of(file).getFileName().toString().toLowerCase();
     for (Map.Entry<String, String> entry : mapping.entrySet()) {
       String lowerKey = entry.getKey().toLowerCase();
       if (lowerFileName.endsWith("." + lowerKey) || lowerFileName.equals(lowerKey)) {


### PR DESCRIPTION
plexus xml no longer needs to be in the pom.  It was there because maven leaked maven 4 into the maven 3 code.  They since fixed the issue.