### PR TITLE
[default] Ignore .groovy folder and cleanup comment on maven ignores

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -129,6 +129,9 @@ public final class Default {
       "**/.gradle-enterprise/**",
       "**/.develocity/**",
 
+      // Groovy files
+      "**/.groovy/**",
+
       // kotlin files
       "**/.kotlin/**",
 
@@ -247,7 +250,7 @@ public final class Default {
       // SourceHut
       "**/.build.yml",
 
-      // Maven 3.3+ configs
+      // Maven
       "**/jvm.config",
       "**/maven.config",
 


### PR DESCRIPTION
Recent groovy versions in eclipse now produce '.groovy' directory.