### PR TITLE
fix(git): follow renames across merges in copyright creation year (#bug)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history is required for GitLookupCreationYearTest, which verifies
+          # that copyright creation year follows renames across merges. A shallow
+          # clone (default fetch-depth=1) would only see the latest commit.
+          fetch-depth: 0
       - name: Set up JDK ${{ matrix.java }} ${{ matrix.distribution }}
         uses: actions/setup-java@v5
         with:

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -26,21 +26,21 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.FollowFilter;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.MaxCountRevFilter;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.RenameDetector;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
-import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.TreeFilter;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Iterator;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -180,7 +180,7 @@ public class GitLookup implements AutoCloseable {
     }
 
     int commitYear = 0;
-    RevWalk walk = getGitRevWalk(repoRelativePath, false);
+    RevWalk walk = getGitRevWalk(repoRelativePath);
     for (RevCommit commit : walk) {
       if (commitsToIgnore.contains(commit.getId())) {
         continue;
@@ -198,51 +198,135 @@ public class GitLookup implements AutoCloseable {
    * Returns the year of creation for the given {@code file} based on the history of the present git branch. The
    * year is taken either from the committer date or from the author identity depending on how {@link #dateSource} was
    * initialized.
+   * <p>
+   * Unlike {@link #getYearOfLastChange(File)}, this method cannot rely on {@link FollowFilter} alone because
+   * {@code FollowFilter} does not traverse merge commits and therefore stops at the first rename that occurs
+   * after a merge, missing the actual creation commit. Instead, this method walks the full history in natural
+   * (newest-first) order and runs {@link RenameDetector} on every commit's diff against all of its parents,
+   * following renames in both directions so that the oldest commit that introduced the file under any of its
+   * historical names is found.
    */
   int getYearOfCreation(File file) throws IOException {
-    String repoRelativePath = pathResolver.relativize(file);
-
-    int commitYear = 0;
-    RevWalk walk = getGitRevWalk(repoRelativePath, true);
-    Iterator<RevCommit> iterator = walk.iterator();
-    if (iterator.hasNext()) {
-      RevCommit commit = iterator.next();
-      commitYear = getYearFromCommit(commit);
-    }
-    walk.dispose();
-
-    // If we couldn't find a creation year from Git assume newly created file
-    if (commitYear == 0) {
+    RevCommit creationCommit = findCreationCommit(file);
+    if (creationCommit == null) {
       return getCurrentYear();
     }
-
-    return commitYear;
+    return getYearFromCommit(creationCommit);
   }
 
   String getAuthorNameOfCreation(File file) throws IOException {
-    String repoRelativePath = pathResolver.relativize(file);
-    String authorName = "";
-    RevWalk walk = getGitRevWalk(repoRelativePath, true);
-    Iterator<RevCommit> iterator = walk.iterator();
-    if (iterator.hasNext()) {
-      RevCommit commit = iterator.next();
-      authorName = getAuthorNameFromCommit(commit);
+    RevCommit creationCommit = findCreationCommit(file);
+    if (creationCommit == null) {
+      return "";
     }
-    walk.dispose();
-    return authorName;
+    return getAuthorNameFromCommit(creationCommit);
   }
 
   String getAuthorEmailOfCreation(File file) throws IOException {
-    String repoRelativePath = pathResolver.relativize(file);
-    String authorEmail = "";
-    RevWalk walk = getGitRevWalk(repoRelativePath, true);
-    Iterator<RevCommit> iterator = walk.iterator();
-    if (iterator.hasNext()) {
-      RevCommit commit = iterator.next();
-      authorEmail = getAuthorEmailFromCommit(commit);
+    RevCommit creationCommit = findCreationCommit(file);
+    if (creationCommit == null) {
+      return "";
     }
-    walk.dispose();
-    return authorEmail;
+    return getAuthorEmailFromCommit(creationCommit);
+  }
+
+  /**
+   * Walks the full git history (newest first) and follows renames across merges to find the commit that first
+   * introduced the given file under any of its historical names.
+   *
+   * @return the creation commit, or {@code null} if the file is not tracked by git (e.g. newly created)
+   */
+  private RevCommit findCreationCommit(File file) throws IOException {
+    String repoRelativePath = pathResolver.relativize(file);
+    DiffConfig diffConfig = repository.getConfig().get(DiffConfig.KEY);
+
+    // Track all known paths that refer to our file (current + renamed predecessors/successors)
+    Set<String> trackedPaths = new HashSet<>();
+    trackedPaths.add(repoRelativePath);
+
+    RevCommit creationCommit = null;
+
+    try (RevWalk walk = new RevWalk(repository)) {
+      walk.markStart(walk.parseCommit(repository.resolve(Constants.HEAD)));
+      walk.setTreeFilter(TreeFilter.ALL);
+      walk.setRevFilter(MaxCountRevFilter.create(checkCommitsCount));
+      walk.setRetainBody(false);
+
+      ObjectId emptyTree = createEmptyTree();
+
+      for (RevCommit c : walk) {
+        RevCommit[] parents = c.getParents();
+        if (parents.length == 0) {
+          // Initial commit: diff against empty tree to detect additions
+          if (touchesAnyPath(diffConfig, emptyTree, c, trackedPaths)) {
+            creationCommit = c;
+          }
+          continue;
+        }
+
+        boolean touched = false;
+        for (RevCommit p : parents) {
+          List<DiffEntry> renames = computeRenames(diffConfig, p.getTree(), c.getTree());
+          for (DiffEntry ent : renames) {
+            String oldP = ent.getOldPath();
+            String newP = ent.getNewPath();
+            boolean oldTracked = trackedPaths.contains(oldP);
+            boolean newTracked = trackedPaths.contains(newP);
+            if (newTracked || oldTracked) {
+              touched = true;
+            }
+            // Follow renames in both directions so that the oldest name is pulled in
+            // as we traverse history backwards (newest first).
+            if (ent.getChangeType() == DiffEntry.ChangeType.RENAME
+                || ent.getChangeType() == DiffEntry.ChangeType.COPY) {
+              if (newTracked && !oldTracked && !oldP.equals(DiffEntry.DEV_NULL)) {
+                trackedPaths.add(oldP);
+              }
+              if (oldTracked && !newTracked && !newP.equals(DiffEntry.DEV_NULL)) {
+                trackedPaths.add(newP);
+              }
+            }
+          }
+        }
+        if (touched) {
+          // In newest-first order, the last touched commit is the oldest.
+          creationCommit = c;
+        }
+      }
+      walk.dispose();
+    }
+
+    return creationCommit;
+  }
+
+  private List<DiffEntry> computeRenames(DiffConfig diffConfig, ObjectId parentTree, ObjectId commitTree) throws IOException {
+    try (TreeWalk tw = new TreeWalk(repository)) {
+      tw.setFilter(TreeFilter.ANY_DIFF);
+      tw.setRecursive(true);
+      tw.reset(parentTree, commitTree);
+      List<DiffEntry> entries = DiffEntry.scan(tw);
+      RenameDetector rd = new RenameDetector(repository.newObjectReader(), diffConfig);
+      rd.addAll(entries);
+      return rd.compute();
+    }
+  }
+
+  private boolean touchesAnyPath(DiffConfig diffConfig, ObjectId parentTree, RevCommit commit, Set<String> paths) throws IOException {
+    List<DiffEntry> entries = computeRenames(diffConfig, parentTree, commit.getTree());
+    for (DiffEntry ent : entries) {
+      if (paths.contains(ent.getNewPath()) || paths.contains(ent.getOldPath())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private ObjectId createEmptyTree() throws IOException {
+    try (org.eclipse.jgit.lib.ObjectInserter ins = repository.newObjectInserter()) {
+      ObjectId id = ins.insert(Constants.OBJ_TREE, new byte[0]);
+      ins.flush();
+      return id;
+    }
   }
 
   boolean isShallowRepository() {
@@ -257,21 +341,20 @@ public class GitLookup implements AutoCloseable {
     return !status.isClean();
   }
 
-  private RevWalk getGitRevWalk(String repoRelativePath, boolean oldestCommitsFirst) throws IOException {
+  private RevWalk getGitRevWalk(String repoRelativePath) throws IOException {
     DiffConfig diffConfig = repository.getConfig().get(DiffConfig.KEY);
 
     RevWalk walk = new RevWalk(repository);
     walk.markStart(walk.parseCommit(repository.resolve(Constants.HEAD)));
-    walk.setTreeFilter(AndTreeFilter.create(Arrays.asList(
-        PathFilter.create(repoRelativePath),
-        FollowFilter.create(repoRelativePath, diffConfig), // Allows us to follow files as they move or are renamed
-        TreeFilter.ANY_DIFF)
-    ));
+    // FollowFilter already performs AND(path, ANY_DIFF) internally and is the only
+    // TreeFilter that supports rename detection: it updates its own path filter to
+    // the prior file name when a rename is encountered while traversing history.
+    // This is sufficient for getYearOfLastChange which only needs the most recent
+    // commit touching the file. getYearOfCreation uses a separate, merge-aware
+    // walk (see findCreationCommit) because FollowFilter does not traverse merges.
+    walk.setTreeFilter(FollowFilter.create(repoRelativePath, diffConfig));
     walk.setRevFilter(MaxCountRevFilter.create(checkCommitsCount));
     walk.setRetainBody(false);
-    if (oldestCommitsFirst) {
-      walk.sort(RevSort.REVERSE);
-    }
 
     return walk;
   }

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupCreationYearTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupCreationYearTest.java
@@ -16,6 +16,7 @@
 package com.mycila.maven.plugin.license.git;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -46,12 +47,18 @@ class GitLookupCreationYearTest {
     File target = new File(repoRoot,
         "license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java");
 
+    // Skip on shallow clones (e.g. GitHub Actions uses fetch-depth=1 by default).
+    // This test requires the full git history to verify rename-following across merges.
     try (GitLookup lookup = GitLookup.create(repoRoot, new java.util.HashMap<>())) {
+      Assumptions.assumeFalse(lookup.isShallowRepository(),
+          "Skipped on shallow clones (CI uses fetch-depth=1); run locally with full history to verify rename-following");
+
       int lastChange = lookup.getYearOfLastChange(target);
       int creation = lookup.getYearOfCreation(target);
 
       // The file was created in 2013 (commit e63e7db2, "first commit") and has been
-      // modified up to the current year.
+      // modified up to the current year. The previous implementation reported 2015
+      // (the rename after the merge) instead of 2013.
       Assertions.assertEquals(2013, creation,
           "copyrightCreationYear should be 2013 (first commit), not the 2015 rename after the merge");
       Assertions.assertTrue(lastChange >= 2024,

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupCreationYearTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/GitLookupCreationYearTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2008-2025 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.git;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+/**
+ * Regression test for the copyright creation year computation on the real license-maven-plugin
+ * repository.
+ * \u003cp\u003e
+ * {@code AbstractLicenseMojo.java} was created in 2013, then renamed twice:
+ * \u003col\u003e
+ * \u003cli\u003e2013: {@code src/main/java/com/google/code/mojo/license/AbstractLicenseMojo.java}
+ *     \u0026rarr; {@code src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java} (R095)\u003c/li\u003e
+ * \u003cli\u003e2015: {@code src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java}
+ *     \u0026rarr; {@code license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java} (R100)\u003c/li\u003e
+ * \u003c/ol\u003e
+ * The 2015 rename happens just after a merge commit. The previous implementation based solely on
+ * {@link org.eclipse.jgit.revwalk.FollowFilter} could not traverse the merge and stopped at 2015,
+ * reporting {@code copyrightCreationYear=2015} instead of 2013.
+ * \u003cp\u003e
+ * This test verifies that {@link GitLookup#getYearOfCreation(File)} follows renames across merges
+ * and returns the actual creation year (2013), matching {@code git log --follow --diff-filter=A}.
+ */
+class GitLookupCreationYearTest {
+
+  @Test
+  void creationYearFollowsRenamesAcrossMerges() throws Exception {
+    File repoRoot = new File(System.getProperty("user.dir")).getParentFile();
+    File target = new File(repoRoot,
+        "license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java");
+
+    try (GitLookup lookup = GitLookup.create(repoRoot, new java.util.HashMap<>())) {
+      int lastChange = lookup.getYearOfLastChange(target);
+      int creation = lookup.getYearOfCreation(target);
+
+      // The file was created in 2013 (commit e63e7db2, "first commit") and has been
+      // modified up to the current year.
+      Assertions.assertEquals(2013, creation,
+          "copyrightCreationYear should be 2013 (first commit), not the 2015 rename after the merge");
+      Assertions.assertTrue(lastChange >= 2024,
+          "copyrightLastYear should be a recent year, got " + lastChange);
+    }
+  }
+}


### PR DESCRIPTION
The copyright creation year (license.git.copyrightCreationYear and license.git.copyrightExistenceYears) was incorrect for files that had been renamed after a merge commit. For example, AbstractLicenseMojo.java was created in 2013, then renamed twice (2013 and 2015), with the 2015 rename occurring just after a merge commit. The plugin reported copyrightExistenceYears=2015-2026 instead of 2013-2026.

Root cause: GitLookup.getYearOfCreation relied on JGit's FollowFilter to follow renames while traversing history in reverse. However, FollowFilter does not traverse merge commits - it only follows a single parent lineage. When a rename happens right after a merge, the walk stops at the rename commit and never reaches the older history on the other parent branch, missing the actual creation commit.

Additionally, FollowFilter was wrapped in an AndTreeFilter together with a fixed PathFilter, which further prevented it from updating its internal path after a rename (FollowFilter is designed to be used alone as the TreeFilter, since it already performs AND(path, ANY_DIFF) internally).

Fix: getYearOfCreation, getAuthorNameOfCreation and getAuthorEmailOfCreation now use a dedicated merge-aware walk (findCreationCommit) that:
  - Walks the full history in natural (newest-first) order with TreeFilter.ALL (no path filtering at the RevWalk level).
  - Runs RenameDetector on every commit's diff against ALL of its parents (including merge commits), so renames are detected across all branches of the history graph.
  - Tracks all known historical names of the file bidirectionally: when a rename is encountered, both the old and new paths are added to the tracked set so that subsequent (older) commits touching any of the file's previous names are still found.
  - Returns the oldest commit that introduced the file under any of its known names (the last touched commit in newest-first order).

getYearOfLastChange is unchanged: it still uses FollowFilter (now used correctly, alone, without the redundant AndTreeFilter/PathFilter) since it only needs the most recent commit and does not need to cross merges.

Verified on the real license-maven-plugin repository:
  AbstractLicenseMojo.java: creation=2013 (was 2015), lastChange=2026.
  Matches 'git log --follow --diff-filter=A'.

Added regression test GitLookupCreationYearTest that asserts getYearOfCreation returns 2013 for AbstractLicenseMojo.java.

All existing tests (GitLookupTest, CopyrightRangeProviderTest, etc.) continue to pass.