### PR TITLE
refactor(tests): migrate tests off deprecated legacyConfig* parameters

### DIFF
--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
@@ -29,9 +29,8 @@ class AdditionalHeaderMojoTest {
   void test_additionalHeaderDefinitions() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/def");
-    check.legacyConfigHeader = "src/test/resources/check/header.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/check/header.txt").excludes("*.xml").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigExcludes = new String[]{"*.xml"};
     check.strictCheck = true;
 
     try {
@@ -49,9 +48,8 @@ class AdditionalHeaderMojoTest {
   void test_inline() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/def");
-    check.legacyConfigHeader = "src/test/resources/check/header.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/check/header.txt").excludes("*.xml").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigExcludes = new String[]{"*.xml"};
 
     try {
       check.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
@@ -35,7 +35,7 @@ class AggregateMojoTest {
     };
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/modules");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = project;
     check.strictCheck = true;
     check.execute();
@@ -52,7 +52,7 @@ class AggregateMojoTest {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.project = project;
     check.defaultBasedir = new File("src/test/resources/check/modules");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.aggregate = true;
     check.strictCheck = true;
     try {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -38,7 +38,7 @@ class CheckTest {
 
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/linewrap");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = project;
 
     // check by default - should work
@@ -60,7 +60,7 @@ class CheckTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/check/linewrap/header.txt").build();
     updater.project = project;
     updater.strictCheck = true;
     updater.execute();
@@ -68,7 +68,7 @@ class CheckTest {
     // the check again, strictly. should work now
     check = new LicenseCheckMojo();
     check.defaultBasedir = tmp;
-    check.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/check/linewrap/header.txt").build();
     check.project = project;
 
     check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CompleteMojoTest.java
@@ -135,8 +135,7 @@ class CompleteMojoTest {
     AbstractLicenseMojo plugin = new LicenseFormatMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -155,8 +154,7 @@ class CompleteMojoTest {
     AbstractLicenseMojo plugin = new LicenseFormatMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -164,8 +162,7 @@ class CompleteMojoTest {
     plugin = new LicenseFormatMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header2.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header2.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -184,8 +181,7 @@ class CompleteMojoTest {
     AbstractLicenseMojo plugin = new LicenseFormatMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -193,8 +189,7 @@ class CompleteMojoTest {
     plugin = new LicenseRemoveMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
     //plugin.setLog(new DebugLog());
 
@@ -214,8 +209,7 @@ class CompleteMojoTest {
     AbstractLicenseMojo plugin = new LicenseCheckMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
 
@@ -236,8 +230,7 @@ class CompleteMojoTest {
     AbstractLicenseMojo plugin = new LicenseFormatMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -245,8 +238,7 @@ class CompleteMojoTest {
     plugin = new LicenseCheckMojo();
     plugin.project = new MavenProjectStub();
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-    plugin.legacyConfigIncludes = new String[]{"file." + extension};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("file." + extension).build();
     plugin.mapping = Collections.singletonMap(extension, headerType.name());
 
     plugin.execute();
@@ -276,8 +268,7 @@ class CompleteMojoTest {
         AbstractLicenseMojo plugin = new LicenseFormatMojo();
         plugin.project = new MavenProjectStub();
         plugin.defaultBasedir = root;
-        plugin.legacyConfigHeader = "src/test/resources/complete/header1.txt";
-        plugin.legacyConfigIncludes = new String[]{"expected1." + extension};
+        plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header1.txt").includes("expected1." + extension).build();
         plugin.mapping = Collections.singletonMap(extension, headerType.name());
         try {
           plugin.execute();
@@ -288,8 +279,7 @@ class CompleteMojoTest {
         plugin = new LicenseFormatMojo();
         plugin.project = new MavenProjectStub();
         plugin.defaultBasedir = root;
-        plugin.legacyConfigHeader = "src/test/resources/complete/header2.txt";
-        plugin.legacyConfigIncludes = new String[]{"expected2." + extension};
+        plugin.licenseSets = LicenseSets.header("src/test/resources/complete/header2.txt").includes("expected2." + extension).build();
         plugin.mapping = Collections.singletonMap(extension, headerType.name());
         try {
           plugin.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
@@ -28,9 +28,8 @@ class ExcludesMojoTest {
   void test_no_exclusions() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").excludes().build();
     check.project = new MavenProjectStub();
-    check.legacyConfigExcludes = new String[0];
     check.strictCheck = true;
     Assertions.assertThrows(MojoExecutionException.class, () -> {
       check.execute();
@@ -41,9 +40,8 @@ class ExcludesMojoTest {
   void test_exclusions() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").excludes("**/*.txt", "**/*.xml", "**/*.java", "**/*.apt.vm").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigExcludes = new String[]{"**/*.txt", "**/*.xml", "**/*.java", "**/*.apt.vm"};
     check.strictCheck = true;
     check.execute();
   }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
@@ -28,7 +28,7 @@ class FailIfMissingMojoTest {
   void test_fail() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.strictCheck = true;
     Assertions.assertThrows(MojoExecutionException.class, () -> {
@@ -40,7 +40,7 @@ class FailIfMissingMojoTest {
   void test_not_fail() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.failIfMissing = false;
     check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
@@ -39,7 +39,7 @@ class HeaderMojoTest {
     MavenProjectStub project = new MavenProjectStub();
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -51,7 +51,7 @@ class HeaderMojoTest {
     MavenProjectStub project = new MavenProjectStub();
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "src/test/resources/check/header.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/check/header.txt").build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -64,7 +64,7 @@ class HeaderMojoTest {
     project.addCompileSourceRoot("src/test/resources/check/cp");
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header-in-cp.txt";
+    check.licenseSets = LicenseSets.header("header-in-cp.txt").build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -76,7 +76,7 @@ class HeaderMojoTest {
     MavenProjectStub project = new MavenProjectStub();
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "test-header1.txt";
+    check.licenseSets = LicenseSets.header("test-header1.txt").build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -88,7 +88,7 @@ class HeaderMojoTest {
     MavenProjectStub project = new MavenProjectStub();
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/check/header.txt"), StandardCharsets.UTF_8);
+    check.licenseSets = LicenseSets.inlineHeader(FileUtils.read(new File("src/test/resources/check/header.txt"), StandardCharsets.UTF_8)).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -102,7 +102,7 @@ class HeaderMojoTest {
     check.defaultBasedir = new File("src/test/resources/check");
     final Multi multi = new Multi();
     multi.setHeaders(new String[]{"header.txt", "header2.txt"});
-    check.legacyConfigMulti = multi;
+    check.licenseSets = LicenseSets.multi(multi).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -116,7 +116,7 @@ class HeaderMojoTest {
     check.defaultBasedir = new File("src/test/resources/check");
     final Multi multi = new Multi();
     multi.setHeaders(new String[]{"src/test/resources/check/header.txt", "src/test/resources/check/header2.txt"});
-    check.legacyConfigMulti = multi;
+    check.licenseSets = LicenseSets.multi(multi).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -131,7 +131,7 @@ class HeaderMojoTest {
     check.defaultBasedir = new File("src/test/resources/check");
     final Multi multi = new Multi();
     multi.setHeaders(new String[]{"header-in-cp.txt", "header-in-cp.txt"});
-    check.legacyConfigMulti = multi;
+    check.licenseSets = LicenseSets.multi(multi).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -145,7 +145,7 @@ class HeaderMojoTest {
     check.defaultBasedir = new File("src/test/resources/check");
     final Multi multi = new Multi();
     multi.setHeaders(new String[]{"test-header1.txt", "test-header2.txt"});
-    check.legacyConfigMulti = multi;
+    check.licenseSets = LicenseSets.multi(multi).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;
@@ -162,7 +162,7 @@ class HeaderMojoTest {
         FileUtils.read(new File("src/test/resources/check/header.txt"), StandardCharsets.UTF_8),
         FileUtils.read(new File("src/test/resources/check/header2.txt"), StandardCharsets.UTF_8)
     });
-    check.legacyConfigMulti = multi;
+    check.licenseSets = LicenseSets.multi(multi).build();
     check.project = project;
     check.failIfMissing = false;
     check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
@@ -28,9 +28,8 @@ class IncludesMojoTest {
   void test_include() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("inexisting").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"inexisting"};
     check.strictCheck = true;
     check.execute();
   }
@@ -39,9 +38,8 @@ class IncludesMojoTest {
   void test_include_and_fail() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("doc1.txt").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"doc1.txt"};
     check.strictCheck = true;
     Assertions.assertThrows(MojoExecutionException.class, () -> {
       check.execute();
@@ -52,9 +50,8 @@ class IncludesMojoTest {
   void test_include_overrides_default_exclusion() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/issues/issue-71");
-    check.legacyConfigHeader = "../../check/header.txt";
+    check.licenseSets = LicenseSets.header("../../check/header.txt").includes("**/.travis.yml").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"**/.travis.yml"};
     Assertions.assertThrows(MojoExecutionException.class, () -> {
       check.execute();
     });

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/LicenseSets.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/LicenseSets.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2008-2025 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license;
+
+import java.io.File;
+
+final class LicenseSets {
+
+  private LicenseSets() {}
+
+  static Builder header(String header) {
+    Builder builder = new Builder();
+    builder.licenseSet.header = header;
+    return builder;
+  }
+
+  static Builder inlineHeader(String inlineHeader) {
+    Builder builder = new Builder();
+    builder.licenseSet.inlineHeader = inlineHeader;
+    return builder;
+  }
+
+  static Builder multi(Multi multi) {
+    Builder builder = new Builder();
+    builder.licenseSet.multi = multi;
+    return builder;
+  }
+
+  static final class Builder {
+
+    private final LicenseSet licenseSet = new LicenseSet();
+
+    private Builder() {}
+
+    Builder validHeaders(String... validHeaders) {
+      licenseSet.validHeaders = validHeaders;
+      return this;
+    }
+
+    Builder includes(String... includes) {
+      licenseSet.includes = includes;
+      return this;
+    }
+
+    Builder excludes(String... excludes) {
+      licenseSet.excludes = excludes;
+      return this;
+    }
+
+    Builder basedir(File basedir) {
+      licenseSet.basedir = basedir;
+      return this;
+    }
+
+    LicenseSet[] build() {
+      return new LicenseSet[]{licenseSet};
+    }
+  }
+}

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
@@ -34,7 +34,7 @@ class MappingMojoTest {
     MockedLog logger = new MockedLog();
     check.setLog(new DefaultLog(logger));
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.useDefaultMapping = true;
     check.strictCheck = true;
@@ -71,9 +71,8 @@ class MappingMojoTest {
     check.setLog(new DefaultLog(logger));
     //check.setLog(new SystemStreamLog());
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("test.apt.vm").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"test.apt.vm"};
     check.defaultProperties = new HashMap<String, String>() {{
       put("year", "2008");
     }};
@@ -102,9 +101,8 @@ class MappingMojoTest {
     check.setLog(new DefaultLog(logger));
     //check.setLog(new SystemStreamLog());
     check.defaultBasedir = new File("src/test/resources/check/issue107");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("test.xml.tmpl").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"test.xml.tmpl"};
     check.defaultProperties = new HashMap<String, String>() {{
       put("year", "2008");
     }};
@@ -128,9 +126,8 @@ class MappingMojoTest {
     check.setLog(new DefaultLog(logger));
     //check.setLog(new SystemStreamLog());
     check.defaultBasedir = new File("src/test/resources/extensionless");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("extensionless-file").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"extensionless-file"};
     check.defaultProperties = new HashMap<String, String>() {{
       put("year", "2008");
     }};
@@ -165,9 +162,8 @@ class MappingMojoTest {
     check.setLog(new DefaultLog(logger));
     //check.setLog(new SystemStreamLog());
     check.defaultBasedir = new File("src/test/resources/unknown");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").includes("file.unknown").build();
     check.project = new MavenProjectStub();
-    check.legacyConfigIncludes = new String[]{"file.unknown"};
     check.defaultProperties = new HashMap<String, String>() {{
       put("year", "2008");
     }};

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
@@ -30,11 +30,10 @@ class QuietMojoTest {
   void test_load_header_from_relative_file() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").excludes("**/issue107/**").build();
     check.project = new MavenProjectStub();
     check.failIfMissing = false;
     check.strictCheck = true;
-    check.legacyConfigExcludes = new String[]{"**/issue107/**"};
 
     MockedLog logger = new MockedLog();
     check.setLog(new DefaultLog(logger));

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
@@ -38,7 +38,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -55,7 +55,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -79,7 +79,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -96,7 +96,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -113,7 +113,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -132,7 +132,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -152,7 +152,7 @@ final class RemoveMojoTest {
 
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
+    remove.licenseSets = LicenseSets.header("src/test/resources/remove/header.txt").build();
     remove.project = new MavenProjectStub();
     remove.execute();
 
@@ -172,14 +172,14 @@ final class RemoveMojoTest {
     // Let's apply the licene
     LicenseFormatMojo format = new LicenseFormatMojo();
     format.defaultBasedir = tmp;
-    format.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
+    format.licenseSets = LicenseSets.header("com/mycila/maven/plugin/license/templates/GPL-3.txt").build();
     format.project = new MavenProjectStub();
     format.execute();
 
     // Let's try to remove it
     LicenseRemoveMojo remove = new LicenseRemoveMojo();
     remove.defaultBasedir = tmp;
-    remove.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
+    remove.licenseSets = LicenseSets.header("com/mycila/maven/plugin/license/templates/GPL-3.txt").build();
     remove.project = new MavenProjectStub();
 //        remove.keywords = new String[]{"GNU"};
     remove.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ReportTest.java
@@ -115,8 +115,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.xml");
 
     try {
@@ -139,8 +138,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.json");
 
     try {
@@ -163,8 +161,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.xml");
 
     plugin.execute();
@@ -183,8 +180,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.json");
 
     plugin.execute();
@@ -203,8 +199,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.xml");
 
     plugin.execute();
@@ -223,8 +218,7 @@ class ReportTest {
     plugin.clock = Clock.fixed(Instant.ofEpochMilli(1631615047644L), ZoneId.systemDefault());
     plugin.project = mavenProjectStub;
     plugin.defaultBasedir = tmp;
-    plugin.legacyConfigHeader = "src/test/resources/issues/issue-122/header.txt";
-    plugin.legacyConfigIncludes = new String[]{"file*.*"};
+    plugin.licenseSets = LicenseSets.header("src/test/resources/issues/issue-122/header.txt").includes("file*.*").build();
     plugin.reportLocation = new File(tmp, "report/license-plugin-report.json");
 
     plugin.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ShallowRepositoryTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ShallowRepositoryTest.java
@@ -42,7 +42,7 @@ class ShallowRepositoryTest {
 
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.skipOnShallow = true;
     check.setLog(new DefaultLog(logger));
@@ -68,7 +68,7 @@ class ShallowRepositoryTest {
 
     LicenseFormatMojo format = new LicenseFormatMojo();
     format.defaultBasedir = new File("src/test/resources/check");
-    format.legacyConfigHeader = "header.txt";
+    format.licenseSets = LicenseSets.header("header.txt").build();
     format.project = new MavenProjectStub();
     format.skipOnShallow = true;
     format.setLog(new DefaultLog(logger));
@@ -89,7 +89,7 @@ class ShallowRepositoryTest {
   void test_failOnShallow_fails_build() {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.failOnShallow = true;
 
@@ -108,7 +108,7 @@ class ShallowRepositoryTest {
 
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     // skipOnShallow=false (default), failOnShallow=false (default)
     check.setLog(new DefaultLog(logger));

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
@@ -37,7 +37,7 @@ class StrictTest {
     // all the headers are by default checked not strictlty
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/issue76");
-    check.legacyConfigHeader = "src/test/resources/test-header1.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/test-header1.txt").build();
     check.project = project;
     check.strictCheck = false;
     check.execute();
@@ -66,7 +66,7 @@ class StrictTest {
     // all the headers are by default checked not strictlty
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/strict");
-    check.legacyConfigHeader = "src/test/resources/test-header1-diff.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/test-header1-diff.txt").build();
     check.project = project;
     check.execute();
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
@@ -44,7 +44,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     updater.project = new MavenProjectStub();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.execute();
@@ -62,7 +62,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/update/header.txt"), StandardCharsets.UTF_8);
+    updater.licenseSets = LicenseSets.inlineHeader(FileUtils.read(new File("src/test/resources/update/header.txt"), StandardCharsets.UTF_8)).build();
     updater.project = new MavenProjectStub();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.execute();
@@ -81,7 +81,7 @@ class UpdateMojoTest {
     // only update those files without a copyright header
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     updater.project = new MavenProjectStub();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.skipExistingHeaders = true;
@@ -93,7 +93,7 @@ class UpdateMojoTest {
     // expect unchanged header to fail check against new header
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = tmp;
-    check.legacyConfigHeader = "src/test/resources/update/header.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     check.project = new MavenProjectStub();
     check.defaultProperties = ImmutableMap.of("year", "2008");
     check.skipExistingHeaders = false;
@@ -121,7 +121,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.mapping = new LinkedHashMap<>() {{
       put("properties", "SCRIPT_STYLE");
@@ -146,7 +146,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.mapping = new LinkedHashMap<>() {{
       put("properties", "SCRIPT_STYLE");
@@ -185,7 +185,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/header.txt").build();
     updater.defaultProperties = ImmutableMap.of("year", "2008");
     updater.project = new MavenProjectStub();
     updater.execute();
@@ -212,7 +212,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/issue14/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/issue14/header.txt").build();
     updater.project = new MavenProjectStub();
     updater.execute();
     final String expectedString = "#" + LS + "" +
@@ -250,7 +250,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/issues/issue-71/issue-71-header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/issues/issue-71/issue-71-header.txt").build();
     updater.project = new MavenProjectStub();
     updater.mapping = new LinkedHashMap<>() {{
       put("txt.extended", "EXTENDED_STYLE");
@@ -273,7 +273,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo execution1 = new LicenseFormatMojo();
     execution1.defaultBasedir = tmp;
-    execution1.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
+    execution1.licenseSets = LicenseSets.header("src/test/resources/update/issue37/xwiki-license.txt").build();
     execution1.project = new MavenProjectStub();
     execution1.execute();
 
@@ -281,7 +281,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo execution2 = new LicenseFormatMojo();
     execution2.defaultBasedir = tmp;
-    execution2.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
+    execution2.licenseSets = LicenseSets.header("src/test/resources/update/issue37/xwiki-license.txt").build();
     execution2.project = new MavenProjectStub();
     execution2.execute();
 
@@ -298,7 +298,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/single-line-header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/single-line-header.txt").build();
     updater.project = new MavenProjectStub();
     updater.execute();
 
@@ -321,12 +321,8 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-
-    LicenseSet licenseSet = new LicenseSet();
-    licenseSet.basedir = tmp;
-    licenseSet.inlineHeader = "All content copyright (c) 2003-2021 Bla, Inc., except as may\n" +
-        "  otherwise be noted in a separate copyright notice. All rights reserved.";
-    updater.licenseSets = new LicenseSet[]{licenseSet};
+    updater.licenseSets = LicenseSets.inlineHeader("All content copyright (c) 2003-2021 Bla, Inc., except as may\n" +
+        "  otherwise be noted in a separate copyright notice. All rights reserved.").basedir(tmp).build();
     updater.project = new MavenProjectStub();
     updater.execute();
 
@@ -354,7 +350,7 @@ class UpdateMojoTest {
 
     LicenseFormatMojo updater = new LicenseFormatMojo();
     updater.defaultBasedir = tmp;
-    updater.legacyConfigHeader = "src/test/resources/update/issue-187/header.txt";
+    updater.licenseSets = LicenseSets.header("src/test/resources/update/issue-187/header.txt").build();
     updater.project = new MavenProjectStub();
     updater.mapping = new LinkedHashMap<>() {{
       put("java", "JAVAPKG_STYLE");

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
@@ -28,9 +28,8 @@ class UseDefaultExcludesMojoTest {
     try {
       LicenseCheckMojo check = new LicenseCheckMojo();
       check.defaultBasedir = new File("src/test/resources/check");
-      check.legacyConfigHeader = "header.txt";
+      check.licenseSets = LicenseSets.header("header.txt").excludes("doc1.txt").build();
       check.project = new MavenProjectStub();
-      check.legacyConfigExcludes = new String[]{"doc1.txt"};
       check.defaultUseDefaultExcludes = false;
       check.strictCheck = true;
       check.execute();
@@ -43,7 +42,7 @@ class UseDefaultExcludesMojoTest {
   void check_defaultExcludes_exclude_Netbeans_Configuration() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/excludes/issue-68");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.defaultUseDefaultExcludes = true;
     check.strictCheck = true;
@@ -55,7 +54,7 @@ class UseDefaultExcludesMojoTest {
     try {
       LicenseCheckMojo check = new LicenseCheckMojo();
       check.defaultBasedir = new File("src/test/resources/excludes/issue-68");
-      check.legacyConfigHeader = "header.txt";
+      check.licenseSets = LicenseSets.header("header.txt").build();
       check.project = new MavenProjectStub();
       check.defaultUseDefaultExcludes = false;
       check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
@@ -28,7 +28,7 @@ class UseDefaultMappingMojoTest {
   void test_not_useDefaultMapping() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.useDefaultMapping = false;
     check.strictCheck = true;
@@ -45,7 +45,7 @@ class UseDefaultMappingMojoTest {
   void test_useDefaultMapping() throws Exception {
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check");
-    check.legacyConfigHeader = "header.txt";
+    check.licenseSets = LicenseSets.header("header.txt").build();
     check.project = new MavenProjectStub();
     check.useDefaultMapping = true;
     check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
@@ -33,7 +33,7 @@ class ValidHeaderMojoTest {
 
     LicenseCheckMojo check = new LicenseCheckMojo();
     check.defaultBasedir = new File("src/test/resources/check/valid");
-    check.legacyConfigHeader = "src/test/resources/test-header1.txt";
+    check.licenseSets = LicenseSets.header("src/test/resources/test-header1.txt").build();
     check.project = new MavenProjectStub();
     check.strictCheck = true;
     try {
@@ -43,7 +43,8 @@ class ValidHeaderMojoTest {
       Assertions.assertEquals("Some files do not have the expected license header. Run license:format to update them.", e.getMessage());
     }
 
-    check.legacyConfigValidHeaders = new String[]{"src/test/resources/check/header2.txt"};
+    check.licenseSets = LicenseSets.header("src/test/resources/test-header1.txt")
+        .validHeaders("src/test/resources/check/header2.txt").build();
     check.execute();
   }
 }


### PR DESCRIPTION
- Related to issue #764 
- Clean up deprecation warnings for `legacyConfigHeader`, `legacyConfigIncludes`, `legacyConfigExcludes`, `legacyConfigMulti` etc
- Mechanical migration (hopefully!) e.g. `legacyConfigHeader` -> `LicenseSet.header` etc
- Created a `package-private` builder `LicenseSets` to reduce boiler place creation of `LicenseSet` array.