### PR TITLE
fix: Avoid loading foreign build extensions when reading licenses (#1084)

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/dependencies/MavenProjectLicenses.java
@@ -20,6 +20,7 @@ import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.License;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.DefaultProjectBuilder;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
@@ -94,7 +95,17 @@ public class MavenProjectLicenses implements LicenseMap, LicenseMessage {
   protected Set<License> getLicensesFromArtifact(final Artifact artifact) {
     Set<License> licenses = new HashSet<>();
     try {
-      MavenProject project = getProjectBuilder().build(artifact, getBuildingRequest()).getProject();
+      // We only need the <licenses> from the POM, not a full project build.
+      // Using the session's default building request (which has processPlugins=true)
+      // would trigger extension realm creation and load foreign build extensions
+      // declared in the dependency's POM into the live Maven session (issue #1084).
+      // Setting processPlugins=false prevents this: the POM is still resolved and
+      // parsed (so <licenses> is available), but plugin/extension processing is skipped.
+      ProjectBuildingRequest request = new DefaultProjectBuildingRequest(getBuildingRequest());
+      request.setProcessPlugins(false);
+      request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+      request.setResolveDependencies(false);
+      MavenProject project = getProjectBuilder().build(artifact, request).getProject();
       licenses.addAll(project.getLicenses());
     } catch (ProjectBuildingException ex) {
       if (getLog().isWarnEnabled()) {


### PR DESCRIPTION
Fixex #1084

getLicensesFromArtifact() was calling ProjectBuilder.build(artifact, ...) with the session's default ProjectBuildingRequest, which has processPlugins=true. This triggered Maven's full project-building pipeline, including extension realm creation — loading build extensions declared in dependencies' POMs into the live Maven session's ClassRealm. A malicious or unexpected extension could then become active in the ClassWorld, and its transitive artifacts would be force-downloaded.

The fix sets processPlugins=false (along with minimal validation and no dependency resolution) on the building request, so the POM is still resolved and parsed to read <licenses>, but plugin/extension processing and class realm population are skipped. This mirrors the pattern used by Maven's own DefaultMavenProjectBuilder.buildFromRepository().